### PR TITLE
[benchmarks & cases] simplify benchmark procedure; add hidet and tvm implementation for transpose

### DIFF
--- a/cases/transpose/BenchmarkTranspose.py
+++ b/cases/transpose/BenchmarkTranspose.py
@@ -1,0 +1,47 @@
+from abc import ABC, abstractmethod
+import numpy as np
+import time
+
+from config import measurement_iterations, warmup_iterations
+
+class BenchmarkTranspose(ABC):
+
+    def __init__(self, name, parallelable):
+        self.name = name
+        self.parallelable = parallelable
+        self.parallel = False
+
+    @abstractmethod
+    def process(self, x):
+        """ Where processing really happens
+
+        Args:
+            x: transformed input data, like torch tensor or tvm NDArray
+
+        Returns:
+            Processed data in the form of ndarray of numpy.
+            (Because some frameworks like hidet and tvm have `lazy execution`,
+            transform the result directly in this function trigger the execution,
+            or there will be some strange bugs)
+
+        """
+        pass
+
+    @abstractmethod
+    def preprocess(self, x_np):
+        pass
+
+    def benchmark(self, x_np, parallel = False):
+        self.parallel = parallel
+        x = self.preprocess(x_np)
+
+        times = []
+        result = []
+        for _ in range(measurement_iterations):
+            start = time.perf_counter()
+            result = self.process(x)
+            end = time.perf_counter()
+            times.append(round((end - start) * 1000, 3))
+        
+        return np.mean(times[warmup_iterations:]), np.array(result), times[:warmup_iterations]
+

--- a/cases/transpose/benchmark.py
+++ b/cases/transpose/benchmark.py
@@ -1,55 +1,38 @@
-import time
 import torch
 import numpy as np
 import multiprocessing
 import pandas as pd
 
-from transpose_triton import benchmark_triton
-# from transpose_hidet import benchmark_hidet
-# from transpose_tvm import benchmark_tvm
-# from transpose_autotvm import benchmark_autotvm
+import config
+from BenchmarkTranspose import BenchmarkTranspose
+from transpose_triton import BenchmarkTriton
+from transpose_hidet import BenchmarkHidet
+from transpose_tvm import BenchmarkTVMNaive, BenchmarkTVMO1
 
-from config import measurement_iterations, benchmark, benchmark_parallel, warmup_iterations
+class BenchmarkTorch(BenchmarkTranspose):
 
-def benchmark_torch(x_np, parallel):
-    """Benchmark PyTorch transpose performance."""
-    x = torch.tensor(x_np, dtype=torch.float32)
+    def __init__(self):
+        super().__init__('torch', True)
+
+    def preprocess(self, x_np):
+        num_threads = multiprocessing.cpu_count() if self.parallel else 1
+        torch.set_num_threads(num_threads)
+        return torch.tensor(x_np, device='cpu', dtype=torch.float32)
+
+    def process(self, x):
+        return torch.transpose(x, 0, 1).contiguous()
+
+def run_benchmark(benchmark, x_np, expect, parallel=False):
+    name = benchmark.name + ('_parallel' if parallel else '')
+    print(f"  Running {name}...")
+    exec_time, result, warmup_times = benchmark.benchmark(x_np)
     
-    num_threads = multiprocessing.cpu_count() if parallel else 1
-    torch.set_num_threads(num_threads)
-
-    # Measure warm-up time
-    warmup_times = []
-    for _ in range(warmup_iterations):
-        warmup_start = time.perf_counter()
-        result = torch.transpose(x, 0, 1).contiguous()
-        warmup_end = time.perf_counter()
-        warmup_times.append((warmup_end - warmup_start) * 1000)
-
-    # Measure execution time
-    times = []
-    for _ in range(measurement_iterations):
-        start = time.perf_counter()
-        result = torch.transpose(x, 0, 1).contiguous()  # Make contiguous for fair comparison
-        end = time.perf_counter()
-        times.append(end - start)
-
-    with torch.no_grad():
-        result_np = result.numpy()
-    
-    return np.mean(times) * 1000, result_np, warmup_times  # Convert to ms
-
-def run_benchmark(method_name, method_func, x_np, expect, parallel=False):
-    """Run a single benchmark and validate results."""
-    print(f"  Running {method_name}{'_parallel' if parallel else ''}...")
-    exec_time, result, warmup_times = method_func(x_np, parallel)
-    
-    assert np.allclose(result, expect, atol=1e-3, rtol=1e-3), f"{method_name} result mismatch!"
+    assert np.allclose(result, expect, atol=1e-3, rtol=1e-3), f"{name} result mismatch!"
     
     return {
-        'Benchmark': benchmark, 
+        'Benchmark': config.benchmark, 
         'Shape': x_np.shape, 
-        'Method': method_name + ('_parallel' if parallel else ''), 
+        'Method': name, 
         'Time(ms)': exec_time, 
         'WarmUpTimes(ms)': warmup_times
     }
@@ -65,22 +48,19 @@ def main():
         x_np = np.random.rand(M, N).astype(np.float32)
         expect = x_np.T
         
-        # Define all methods
-        methods = [
-            ('torch', benchmark_torch),
-            ('triton', benchmark_triton),
-            # ('hidet', benchmark_hidet),
-            # ('tvm', benchmark_tvm),
+        benchmarks = [
+            BenchmarkTorch(),
+            BenchmarkTriton(),
+            BenchmarkTVMNaive(),
+            BenchmarkTVMO1(),
+            BenchmarkHidet(),
             # ('autotvm', benchmark_autotvm),
         ]
         
-        for method, method_func in methods:
-            # Run without parallelism
-            records.append(run_benchmark(method, method_func, x_np, expect, False))
-            
-            # Run with parallelism if enabled
-            if benchmark_parallel:
-                records.append(run_benchmark(method, method_func, x_np, expect, True))
+        for benchmark in benchmarks:
+            records.append(run_benchmark(benchmark, x_np, expect))
+            if config.benchmark_parallel and benchmark.parallelable:
+                records.append(run_benchmark(benchmark, x_np, expect, True))
     
     # Create and save the benchmark results
     df = pd.DataFrame(records)
@@ -89,7 +69,8 @@ def main():
     df.sort_values(by=["Shape"])
     print("\nBenchmark Results:")
     print(df)
-    df.to_csv(f"./{benchmark}_performance_report.csv", index=False)
+    df.to_csv(f"./{config.benchmark}_performance_report.csv", index=False)
 
 if __name__ == "__main__":
-    main() 
+    main()
+

--- a/cases/transpose/config.py
+++ b/cases/transpose/config.py
@@ -1,0 +1,6 @@
+benchmark = "transpose"
+warmup_iterations = 10  # Warmup iterations before timing
+measurement_iterations = 20  # Number of iterations for measurement
+benchmark_parallel = True
+# repeat_runs = 3  # Number of times to repeat the entire benchmark
+# confidence_interval = 0.95  # For calculating confidence intervals

--- a/cases/transpose/transpose_hidet.py
+++ b/cases/transpose/transpose_hidet.py
@@ -1,0 +1,29 @@
+import numpy as np
+import hidet
+from BenchmarkTranspose import BenchmarkTranspose
+
+class BenchmarkHidet(BenchmarkTranspose):
+
+    def __init__(self):
+        super().__init__('hidet', False)
+
+    def preprocess(self, x_np):
+        return hidet.graph.from_numpy(x_np)
+
+    def process(self, x):
+        return hidet.ops.transpose(x).numpy()
+
+if __name__ == "__main__":
+    M, N = 1024, 768
+    x_np = np.random.rand(M, N).astype(np.float32)
+
+    benchmark = BenchmarkHidet()
+    time_hidet, result_hidet, warmup_times = benchmark.benchmark(x_np)
+
+    # Verify correctness
+    expected = x_np.transpose()
+    assert np.allclose(result_hidet, expected, atol=1e-3, rtol=1e-3), (
+        "Hidet result mismatch!"
+    )
+
+    print(f"hidet: {time_hidet}, warmup times: {warmup_times}")

--- a/cases/transpose/transpose_triton.py
+++ b/cases/transpose/transpose_triton.py
@@ -2,10 +2,9 @@ import torch
 import numpy as np
 import triton
 import triton.language as tl
-import time
 import os
 
-from config import measurement_iterations, warmup_iterations
+from BenchmarkTranspose import BenchmarkTranspose
 
 def get_configs():
     configs = []
@@ -90,50 +89,32 @@ def transpose(x, y=None):
     
     return y
 
-def benchmark_triton(x_np, parallel=False):
-    """Benchmark the Triton implementation of transpose."""
-    os.environ["TRITON_CPU_BACKEND"] = "1"
-    os.environ["TRITON_CPU_MAX_THREADS"] = "0" if parallel else "1"
-    
-    M, N = x_np.shape
-    x = torch.tensor(x_np, device='cpu', dtype=torch.float32)
-    assert x.is_contiguous(), "Input matrix must be contiguous"
-    
-    y = torch.empty((N, M), device='cpu', dtype=torch.float32)
-    
-    warmup_times = []
-    tuning_start = time.perf_counter()
-    
-    # Run warmup iterations (first one triggers autotuning)
-    for i in range(warmup_iterations):
-        iter_start = time.perf_counter()
-        transpose(x, y)
-        iter_end = time.perf_counter()
-        warmup_times.append((iter_end - iter_start) * 1000)  # Convert to ms
-    
-    # Now benchmark the execution time (post-tuning)
-    times = []
-    for _ in range(measurement_iterations):  # Match loop_times from benchmark.py
-        start = time.perf_counter()
-        transpose(x, y)
-        end = time.perf_counter()
-        times.append(end - start)
-    
-    return np.mean(times) * 1000, y.numpy(), warmup_times
+class BenchmarkTriton(BenchmarkTranspose):
+
+    def __init__(self):
+        super().__init__('triton', True)
+
+    def preprocess(self, x_np):
+        os.environ["TRITON_CPU_BACKEND"] = "1"
+        os.environ["TRITON_CPU_MAX_THREADS"] = "0" if self.parallel else "1"
+        return torch.tensor(x_np, device='cpu', dtype=torch.float32)
+
+    def process(self, x):
+        return transpose(x)
 
 if __name__ == "__main__":
     M, N = 1024, 768
     x_np = np.random.rand(M, N).astype(np.float32)
-    shape = (M, N)
+    benchmarkTriton = BenchmarkTriton()
+    expect = x_np.transpose()
     
-    time_triton, result_triton, tuning_time = benchmark_triton(x_np, False)
-    time_triton_parallel, result_triton_parallel, tuning_time_parallel = benchmark_triton(x_np, False)
+    time_triton, result_triton, warmup_times = benchmarkTriton.benchmark(x_np)
+    time_triton_parallel, result_triton_parallel, warpup_times_parallel = benchmarkTriton.benchmark(x_np, True)
     
     # Verify correctness
-    expected = x_np.transpose()
-    assert np.allclose(result_triton, expected, atol=1e-3, rtol=1e-3), "Triton result mismatch!"
-    assert np.allclose(result_triton_parallel, expected, atol=1e-3, rtol=1e-3), "Triton parallel result mismatch!"
+    assert np.allclose(result_triton, expect, atol=1e-3, rtol=1e-3), "Triton result mismatch!"
+    assert np.allclose(result_triton_parallel, expect, atol=1e-3, rtol=1e-3), "Triton parallel result mismatch!"
     
-    print(f"Triton single: {time_triton:.3f} ms (tuning: {tuning_time:.3f} ms)")
-    print(f"Triton parallel: {time_triton_parallel:.3f} ms (tuning: {tuning_time_parallel:.3f} ms)")
-    
+    print(f"Triton single: {time_triton} ms (tuning: {warmup_times} ms)")
+    print(f"Triton parallel: {time_triton_parallel} ms (tuning: {warmup_times} ms)")
+

--- a/cases/transpose/transpose_tvm.py
+++ b/cases/transpose/transpose_tvm.py
@@ -1,0 +1,90 @@
+import numpy as np
+import tvm
+from tvm import te
+import tvm.topi as topi
+from BenchmarkTranspose import BenchmarkTranspose
+
+class BenchmarkTVMNaive(BenchmarkTranspose):
+
+    def __init__(self):
+        super().__init__('tvm-naive', False)
+        
+    def preprocess(self, x_np):
+        # Create TVM context and tensors
+        self.M, self.N = x_np.shape
+        self.dtype = str(x_np.dtype)
+        
+        # Define the computation
+        A = te.placeholder((self.M, self.N), name='A', dtype=self.dtype)
+        B: tvm.te.Tensor = topi.transpose(A)
+        
+        # Create schedule
+        s = te.create_schedule(B.op)
+        
+        # Build the function
+        self.func = tvm.build(s, [A, B], target="llvm", name="transpose")
+        
+        # Create TVM arrays
+        self.a_tvm = tvm.nd.array(x_np, device=tvm.cpu())
+        self.b_tvm = tvm.nd.empty((self.N, self.M), dtype=self.dtype, device=tvm.cpu())
+        
+        return self.a_tvm
+        
+    def process(self, x):
+        # Execute the function
+        self.func(x, self.b_tvm)
+        return self.b_tvm.numpy()
+
+class BenchmarkTVMO1(BenchmarkTranspose):
+    """Optimized with parallelism, vectorize and loop tiling"""
+
+    def __init__(self):
+        super().__init__('tvm-o1', False)
+
+    def preprocess(self, x_np):
+        self.M, self.N = x_np.shape
+        self.dtype = str(x_np.dtype)
+
+        A = te.placeholder((self.M, self.N), name='A', dtype=self.dtype)
+        B: tvm.te.Tensor = topi.transpose(A)
+
+        s: tvm.te.schedule.Schedule = te.create_schedule(B.op)
+
+        block_size = 32  # TODO: Tune this based on CPU cache line size
+        x, y = s[B].op.axis
+
+        # **Loop Tiling (Cache Optimization)**
+        xo, _ = s[B].split(x, factor=block_size)
+        _, yi = s[B].split(y, factor=block_size)
+
+        s[B].parallel(xo)  # Parallelize the outer loop
+        s[B].vectorize(yi)  # Apply vectorization to the inner loop
+
+        # Build the optimized function
+        self.func = tvm.build(s, [A, B], target="llvm", name="transpose")
+
+        # Allocate TVM arrays
+        self.a_tvm = tvm.nd.array(x_np, device=tvm.cpu())
+        self.b_tvm = tvm.nd.empty((self.N, self.M), dtype=self.dtype, device=tvm.cpu())
+
+        return self.a_tvm
+
+    def process(self, x):
+        # Execute the compiled function
+        self.func(x, self.b_tvm)
+        return self.b_tvm.numpy()
+
+if __name__ == "__main__":
+    M, N = 1024, 768
+    x_np = np.random.rand(M, N).astype(np.float32)
+
+    benchmark = BenchmarkTVMO1()
+    time_tvm, result_tvm, warmup_times = benchmark.benchmark(x_np)
+
+    # Verify correctness
+    expected = x_np.transpose()
+    assert np.allclose(result_tvm, expected, atol=1e-3, rtol=1e-3), (
+        "TVM result mismatch!"
+    )
+
+    print(f"tvm: {time_tvm}, warmup times: {warmup_times}") 


### PR DESCRIPTION
**Main changes:**
1. Add config.py for global benchmark parameters
2. Greatly simplify benchmark procedure by refactor benchmark functions, which is achieved by intrudocing abstract class.
3. Use warmup iterations and measurement iterations to get a more comprehensive result
4. Add autotuning for triton method, both single and paralleled
5. Add hidet and tvm(naive and optimized) implementation for transpose

**Why adding warmup iterations?**
Since there are so many factors that could possibly and greatly influence the execution time before it finally stabalized, like paralellism and autotuning, so it would be necessary to observe the first n times of execution times.

**Result:**
![Screenshot_20250320_234228](https://github.com/user-attachments/assets/c68d8b1f-c39a-4066-adfc-c51b42d364a5)