### PR TITLE
[cases-conv2d] add hidet, tvm and ansor implementation

### DIFF
--- a/cases/conv2d/benchmark.py
+++ b/cases/conv2d/benchmark.py
@@ -1,4 +1,3 @@
-import time
 import torch
 import numpy as np
 import multiprocessing
@@ -6,6 +5,9 @@ import pandas as pd
 
 from BenchmarkConv2d import BenchmarkConv2d
 from conv2d_triton import BenchmarkConv2dTriton
+from conv2d_tvm import BenchmarkConv2dTVM, BenchmarkConv2dTVMO1
+from conv2d_hidet import BenchmarkConv2dHidet
+from conv2d_ansor import BenchmarkConv2dAnsor
 import config
 
 class BenchmarkConv2dTorch(BenchmarkConv2d):
@@ -60,6 +62,10 @@ def main():
         benchmarks: list[BenchmarkConv2d] = [
             BenchmarkConv2dTorch(),
             BenchmarkConv2dTriton(),
+            BenchmarkConv2dTVM(),
+            BenchmarkConv2dTVMO1(),
+            BenchmarkConv2dHidet(),
+            BenchmarkConv2dAnsor()
         ]
 
         print(f"Benchmarking with input shape {x_np.shape}, weight shape {w_np.shape}")
@@ -72,7 +78,6 @@ def main():
     df = pd.DataFrame(records)
     df["Time(ms)"] = df["Time(ms)"].apply(lambda x: round(x, 3))
     df["WarmUpTimes(ms)"] = df["WarmUpTimes(ms)"].apply(lambda x: ', '.join(f"{t:.3f}" for t in x))
-    df = df.sort_values(by=["Shape"])
     print("\nBenchmark Results:")
     print(df)
     df.to_csv(f"./{config.benchmark}_performance_report.csv", index=False)

--- a/cases/conv2d/conv2d_ansor.py
+++ b/cases/conv2d/conv2d_ansor.py
@@ -1,0 +1,87 @@
+import numpy as np
+import torch
+import tvm
+from tvm import te, topi
+from tvm import auto_scheduler
+from BenchmarkConv2d import BenchmarkConv2d
+
+@auto_scheduler.register_workload
+def conv2d(input_shape, weight_shape, has_bias, stride, padding, dilation, groups, dtype):
+    data = te.placeholder(input_shape, name="data", dtype=dtype)
+    kernel = te.placeholder(weight_shape, name="kernel", dtype=dtype)
+    out = topi.nn.conv(data, kernel, stride, padding, dilation, groups, "NCHW", out_dtype=dtype)
+    if has_bias:
+        bias = te.placeholder((weight_shape[0],), name="bias", dtype=dtype)
+        out = topi.add(out, topi.reshape(bias, (1, weight_shape[0], 1, 1)))
+        return [data, kernel, bias, out]
+    return [data, kernel, out]
+
+class BenchmarkConv2dAnsor(BenchmarkConv2d):
+
+    def __init__(self):
+        super().__init__('tvm_ansor', False)
+
+    def preprocess(self, x_np, w_np, b_np, stride, padding, dilation, groups):
+        stride = (stride, stride) if isinstance(stride, int) else stride
+        padding = (padding, padding) if isinstance(padding, int) else padding
+        dilation = (dilation, dilation) if isinstance(dilation, int) else dilation
+        self.has_bias = b_np is not None
+
+        target = tvm.target.Target("llvm")
+        task = auto_scheduler.SearchTask(
+            func=conv2d,
+            args=(x_np.shape, w_np.shape, self.has_bias, stride, padding, dilation, groups, str(x_np.dtype)),
+            target=target
+        )
+
+        # print("Computational DAG for conv2d auto_scheduler:")
+        # print(task.compute_dag)
+
+        log_file = "conv2d-auto_scheduler.json"
+        tune_option = auto_scheduler.TuningOptions(
+            num_measure_trials=10, # TODO: How many trials will be good?
+            measure_callbacks=[auto_scheduler.RecordToFile(log_file)],
+            verbose=2,
+        )
+
+        task.tune(tune_option)
+        sch, args = task.apply_best(log_file)
+        self.func = tvm.build(sch, args, "llvm")
+
+        # print("Lowered TIR:")
+        # print(tvm.lower(sch, args, simple_mode=True))
+
+        # prepare tvm tensors
+        self.input_tvm = tvm.nd.array(x_np, device=tvm.cpu())
+        self.weight_tvm = tvm.nd.array(w_np, device=tvm.cpu())
+        self.bias_tvm = tvm.nd.array(b_np, device=tvm.cpu()) if self.has_bias else None
+
+        out_height = (x_np.shape[2] + 2 * padding[0] - dilation[0] * (w_np.shape[2] - 1) - 1) // stride[0] + 1
+        out_width = (x_np.shape[3] + 2 * padding[1] - dilation[1] * (w_np.shape[3] - 1) - 1) // stride[1] + 1
+        self.out_tvm = tvm.nd.empty((x_np.shape[0], w_np.shape[0], out_height, out_width))
+
+    def process(self):
+        if self.has_bias:
+            self.func(self.input_tvm, self.weight_tvm, self.bias_tvm, self.out_tvm)
+        else:
+            self.func(self.input_tvm, self.weight_tvm, self.out_tvm)
+        return self.out_tvm.numpy()
+
+
+if __name__ == "__main__":
+    batch_size, in_channels, in_height, in_width = 1, 3, 32, 32
+    out_channels, kernel_height, kernel_width = 16, 3, 3
+
+    x_np = np.random.rand(batch_size, in_channels, in_height, in_width).astype(np.float32)
+    w_np = np.random.rand(out_channels, in_channels, kernel_height, kernel_width).astype(np.float32)
+    b_np = np.random.rand(out_channels).astype(np.float32)
+
+    x_torch = torch.tensor(x_np, dtype=torch.float32)
+    w_torch = torch.tensor(w_np, dtype=torch.float32)
+    b_torch = torch.tensor(b_np, dtype=torch.float32)
+    expected = torch.nn.functional.conv2d(x_torch, w_torch, b_torch).numpy()
+
+    benchmark = BenchmarkConv2dAnsor()
+    result = benchmark.benchmark(x_np, w_np, expected, b_np, 1, 0, 1, 1, False)
+    print(f"{result}")
+

--- a/cases/conv2d/conv2d_hidet.py
+++ b/cases/conv2d/conv2d_hidet.py
@@ -1,0 +1,67 @@
+# Hidet Benchmark
+# Refer to: https://hidet.org/docs/stable/python_api/ops/index.html
+
+import numpy as np
+import torch
+import hidet
+from BenchmarkConv2d import BenchmarkConv2d
+
+
+class BenchmarkConv2dHidet(BenchmarkConv2d):
+
+    def __init__(self):
+        super().__init__('hidet', False)
+
+    def preprocess(self, x_np, w_np, b_np, stride, padding, dilation, groups):
+        hidet.option.cache_dir('./.hidet/cache')
+
+        # Convert NumPy arrays to Hidet tensors
+        self.input = hidet.graph.from_numpy(x_np)
+        self.weight = hidet.graph.from_numpy(w_np)
+        self.bias = hidet.graph.from_numpy(b_np) if b_np is not None else None
+
+        # Store the convolution parameters
+        self.stride = stride
+        self.padding = padding
+        self.dilation = dilation
+        self.groups = groups
+
+    def process(self):
+        # Execute the convolution operation
+        output = hidet.ops.conv2d(
+            self.input, 
+            self.weight,
+            stride=self.stride,
+            padding=self.padding,
+            dilations=self.dilation,
+            groups=self.groups
+        )
+
+        # Add bias manually if it exists
+        if self.bias is not None:
+            output = output + self.bias.reshape((1, -1, 1, 1))  # Ensure proper broadcasting
+
+        return output.numpy()
+
+
+if __name__ == "__main__":
+    # Test the convolution with a simple example
+    batch_size, in_channels, in_height, in_width = 1, 3, 32, 32
+    out_channels, kernel_height, kernel_width = 16, 3, 3
+
+    x_np = np.random.rand(batch_size, in_channels, in_height, in_width).astype(np.float32)
+    w_np = np.random.rand(out_channels, in_channels, kernel_height, kernel_width).astype(np.float32)
+    b_np = np.random.rand(out_channels).astype(np.float32)
+
+    # Verify with PyTorch
+    x_torch = torch.tensor(x_np, dtype=torch.float32)
+    w_torch = torch.tensor(w_np, dtype=torch.float32)
+    b_torch = torch.tensor(b_np, dtype=torch.float32)
+    expected = torch.nn.functional.conv2d(x_torch, w_torch, b_torch).numpy()
+
+    # Test with Hidet
+    benchmark = BenchmarkConv2dHidet()
+    result = benchmark.benchmark(x_np, w_np, expected, b_np, 1, 0, 1, 1, False)
+
+    print(f"{result}")
+

--- a/cases/conv2d/conv2d_triton.py
+++ b/cases/conv2d/conv2d_triton.py
@@ -6,15 +6,13 @@ import triton
 import triton.language as tl
 import os
 
-from config import measurement_iterations, warmup_iterations
-
 from BenchmarkConv2d import BenchmarkConv2d
 
 def get_configs():
     configs = []
-    for BLOCK_NI_HO_WO in [32, 64, 128]:
-        for BLOCK_CI in [16, 32]:
-            for BLOCK_CO in [16, 32, 64]:
+    for BLOCK_NI_HO_WO in [4, 8, 32]:
+        for BLOCK_CI in [4, 8, 16, 32, 64]:
+            for BLOCK_CO in [4, 8, 16]:
                 configs.append(triton.Config({
                     'BLOCK_NI_HO_WO': BLOCK_NI_HO_WO,
                     'BLOCK_CI': BLOCK_CI,
@@ -261,6 +259,7 @@ class BenchmarkConv2dTriton(BenchmarkConv2d):
             dilation_w,
             self.groups,
         )
+        # print(f"Best config: {conv2d_kernel.best_config}")
         
         return output
 

--- a/cases/conv2d/conv2d_tvm.py
+++ b/cases/conv2d/conv2d_tvm.py
@@ -1,0 +1,238 @@
+# TVM Benchmark
+# Refer to: https://tvm.apache.org/docs/reference/api/python/topi.html#tvm.topi.nn.conv2d
+
+import numpy as np
+import torch
+import tvm
+from tvm import te, topi
+from BenchmarkConv2d import BenchmarkConv2d
+
+
+class BenchmarkConv2dTVM(BenchmarkConv2d):
+
+    def __init__(self):
+        super().__init__('tvm', True)
+
+    def preprocess(self, x_np, w_np, b_np, stride, padding, dilation, groups):
+        self.input_shape = x_np.shape
+        self.weight_shape = w_np.shape
+        self.dtype = str(x_np.dtype)
+
+        # Convert to TVM tensors
+        self.input_tvm = tvm.nd.array(x_np, device=tvm.cpu())
+        self.weight_tvm = tvm.nd.array(w_np, device=tvm.cpu())
+        self.bias_tvm = tvm.nd.array(b_np, device=tvm.cpu()) if b_np is not None else None
+
+        # Handle parameter formats
+        self.stride = (stride, stride) if isinstance(stride, int) else stride
+        self.padding = (padding, padding) if isinstance(padding, int) else padding
+        self.dilation = (dilation, dilation) if isinstance(dilation, int) else dilation
+        self.groups = groups
+
+        # Create placeholders for the computation
+        batch_size, in_channels, in_height, in_width = x_np.shape
+        out_channels, in_channels_per_group, kernel_height, kernel_width = w_np.shape
+
+        # Create input and weight tensors
+        A = te.placeholder((batch_size, in_channels, in_height, in_width), name='A', dtype=self.dtype)
+        W = te.placeholder((out_channels, in_channels_per_group, kernel_height, kernel_width), name='W', dtype=self.dtype)
+
+        # Define the convolution computation
+        stride_h, stride_w = self.stride
+        padding_h, padding_w = self.padding
+        dilation_h, dilation_w = self.dilation
+
+        # Compute output dimensions
+        out_height = (in_height + 2 * padding_h - dilation_h * (kernel_height - 1) - 1) // stride_h + 1
+        out_width = (in_width + 2 * padding_w - dilation_w * (kernel_width - 1) - 1) // stride_w + 1
+
+        if groups == 1:
+            # Standard convolution
+            B = topi.nn.conv2d(A, W, strides=self.stride, padding=self.padding, dilation=self.dilation, out_dtype=self.dtype)
+        else:
+            # Split input and weights into `groups` and perform grouped convolution
+            A_splits = te.compute((groups, batch_size, in_channels // groups, in_height, in_width), lambda g, n, c, h, w: A[n, g * (in_channels // groups) + c, h, w], name="A_splits")
+            W_splits = te.compute((groups, out_channels // groups, in_channels // groups, kernel_height, kernel_width), lambda g, oc, ic, kh, kw: W[g * (out_channels // groups) + oc, ic, kh, kw], name="W_splits")
+
+            B_splits = [topi.nn.conv2d(A_splits[g], W_splits[g], strides=self.stride, padding=self.padding, dilation=self.dilation, out_dtype=self.dtype) for g in range(groups)]
+
+            B = topi.concatenate(B_splits, axis=1)  # Concatenate along the channel dimension
+
+        # Add bias if provided
+        if b_np is not None:
+            bias = te.placeholder((out_channels,), name='bias', dtype=self.dtype)
+            B = topi.add(B, topi.reshape(bias, (1, out_channels, 1, 1)))
+            self.has_bias = True
+        else:
+            self.has_bias = False
+
+        s = te.create_schedule(B.op)
+
+        # Apply parallelization if needed
+        if self.parallel:
+            output_op = s[B].op
+            if isinstance(output_op, tvm.te.ComputeOp):
+                n, f, y, x = output_op.axis
+                s[B].parallel(n)
+
+        # Build the function
+        if self.has_bias:
+            self.func = tvm.build(s, [A, W, bias, B], target="llvm", name="conv2d")
+            self.output_tvm = tvm.nd.empty((batch_size, out_channels, out_height, out_width), 
+                                        dtype=self.dtype, device=tvm.cpu())
+        else:
+            self.func = tvm.build(s, [A, W, B], target="llvm", name="conv2d")
+            self.output_tvm = tvm.nd.empty((batch_size, out_channels, out_height, out_width), 
+                                        dtype=self.dtype, device=tvm.cpu())
+
+    def process(self):
+        # Execute the function
+        if self.has_bias:
+            self.func(self.input_tvm, self.weight_tvm, self.bias_tvm, self.output_tvm)
+        else:
+            self.func(self.input_tvm, self.weight_tvm, self.output_tvm)
+
+        return self.output_tvm.numpy()
+
+
+class BenchmarkConv2dTVMO1(BenchmarkConv2d):
+    """Optimized TVM implementation with adaptive tiling and parallelism"""
+
+    def __init__(self):
+        super().__init__('tvm-o1', True)
+
+    def preprocess(self, x_np, w_np, b_np, stride, padding, dilation, groups):
+        self.input_shape = x_np.shape
+        self.weight_shape = w_np.shape
+        self.dtype = str(x_np.dtype)
+
+        self.input_tvm = tvm.nd.array(x_np, device=tvm.cpu())
+        self.weight_tvm = tvm.nd.array(w_np, device=tvm.cpu())
+        self.bias_tvm = tvm.nd.array(b_np, device=tvm.cpu()) if b_np is not None else None
+
+        self.stride = (stride, stride) if isinstance(stride, int) else stride
+        self.padding = (padding, padding) if isinstance(padding, int) else padding
+        self.dilation = (dilation, dilation) if isinstance(dilation, int) else dilation
+        self.groups = groups
+
+        batch_size, in_channels, in_height, in_width = x_np.shape
+        out_channels, in_channels_per_group, kernel_height, kernel_width = w_np.shape
+
+        A = te.placeholder((batch_size, in_channels, in_height, in_width), name='A', dtype=self.dtype)
+        W = te.placeholder((out_channels, in_channels_per_group, kernel_height, kernel_width), name='W', dtype=self.dtype)
+
+        stride_h, stride_w = self.stride
+        padding_h, padding_w = self.padding
+        dilation_h, dilation_w = self.dilation
+
+        out_height = (in_height + 2 * padding_h - dilation_h * (kernel_height - 1) - 1) // stride_h + 1
+        out_width = (in_width + 2 * padding_w - dilation_w * (kernel_width - 1) - 1) // stride_w + 1
+
+        if groups == 1:
+            # Standard convolution
+            B = topi.nn.conv2d(A, W, strides=self.stride, padding=self.padding, dilation=self.dilation, out_dtype=self.dtype)
+        else:
+            # Split input and weights into `groups` and perform grouped convolution
+            A_splits = te.compute((groups, batch_size, in_channels // groups, in_height, in_width), lambda g, n, c, h, w: A[n, g * (in_channels // groups) + c, h, w], name="A_splits")
+            W_splits = te.compute((groups, out_channels // groups, in_channels // groups, kernel_height, kernel_width), lambda g, oc, ic, kh, kw: W[g * (out_channels // groups) + oc, ic, kh, kw], name="W_splits")
+
+            B_splits = [topi.nn.conv2d(A_splits[g], W_splits[g], strides=self.stride, padding=self.padding, dilation=self.dilation, out_dtype=self.dtype) for g in range(groups)]
+
+            B = topi.concatenate(B_splits, axis=1)  # Concatenate along the channel dimension
+
+        # Add bias if provided
+        if b_np is not None:
+            bias = te.placeholder((out_channels,), name='bias', dtype=self.dtype)
+            B = topi.add(B, topi.reshape(bias, (1, out_channels, 1, 1)))
+            self.has_bias = True
+        else:
+            self.has_bias = False
+
+        s = te.create_schedule(B.op)
+
+        # Apply optimization strategies
+        # Get the output axes
+        n, f, y, x = s[B].op.axis
+
+        # Adapt tile sizes based on input dimensions
+        # For larger inputs, use larger tiles to reduce overhead
+        if out_width >= 56:
+            tile_size_n = min(batch_size, 2)  # Adapt to batch size
+            tile_size_f = min(32, out_channels // 2)  # Adapt to output channels
+            tile_size_y = min(8, out_height // 4)
+            tile_size_x = min(32, out_width // 4)
+        else:
+            tile_size_n = 1
+            tile_size_f = min(16, out_channels // 2)
+            tile_size_y = min(4, out_height // 2)
+            tile_size_x = min(16, out_width // 2)
+
+        # Apply tiling to the axes
+        no, ni = s[B].split(n, factor=tile_size_n)
+        fo, fi = s[B].split(f, factor=tile_size_f)
+        yo, yi = s[B].split(y, factor=tile_size_y)
+        xo, xi = s[B].split(x, factor=tile_size_x)
+
+        # Choose different reordering based on problem size
+        if out_channels >= 64:
+            # For larger problems, parallelize over channels
+            s[B].reorder(fo, no, yo, xo, ni, fi, yi, xi)
+            if self.parallel:
+                s[B].parallel(fo)  # Parallelize over output channels
+        else:
+            # For smaller problems, focus on spatial locality
+            s[B].reorder(no, fo, yo, xo, ni, fi, yi, xi)
+            if self.parallel:
+                # Choose whether to parallelize batch or channels
+                if batch_size > 1:
+                    s[B].parallel(no)
+                else:
+                    s[B].parallel(fo)
+
+        # Apply vectorization to the innermost loop if the width is large enough
+        if out_width >= 16:
+            s[B].vectorize(xi)
+
+        # Build the function
+        if self.has_bias:
+            self.func = tvm.build(s, [A, W, bias, B], target="llvm", name="conv2d_o1")
+            self.output_tvm = tvm.nd.empty((batch_size, out_channels, out_height, out_width), 
+                                        dtype=self.dtype, device=tvm.cpu())
+        else:
+            self.func = tvm.build(s, [A, W, B], target="llvm", name="conv2d_o1")
+            self.output_tvm = tvm.nd.empty((batch_size, out_channels, out_height, out_width), 
+                                        dtype=self.dtype, device=tvm.cpu())
+
+    def process(self):
+        # Execute the function
+        if self.has_bias:
+            self.func(self.input_tvm, self.weight_tvm, self.bias_tvm, self.output_tvm)
+        else:
+            self.func(self.input_tvm, self.weight_tvm, self.output_tvm)
+        
+        return self.output_tvm.numpy()
+
+
+if __name__ == "__main__":
+    # Test the convolution with a simple example
+    batch_size, in_channels, in_height, in_width = 1, 3, 32, 32
+    out_channels, kernel_height, kernel_width = 16, 3, 3
+    
+    x_np = np.random.rand(batch_size, in_channels, in_height, in_width).astype(np.float32)
+    w_np = np.random.rand(out_channels, in_channels, kernel_height, kernel_width).astype(np.float32)
+    b_np = np.random.rand(out_channels).astype(np.float32)
+    
+    # Verify with PyTorch
+    x_torch = torch.tensor(x_np, dtype=torch.float32)
+    w_torch = torch.tensor(w_np, dtype=torch.float32)
+    b_torch = torch.tensor(b_np, dtype=torch.float32)
+    expected = torch.nn.functional.conv2d(x_torch, w_torch, b_torch).numpy()
+
+    # Test with TVM
+    benchmark = BenchmarkConv2dTVMO1()
+    result = benchmark.benchmark(x_np, w_np, expected, b_np, 1, 0, 1, 1, False)
+    result_parallel = benchmark.benchmark(x_np, w_np, expected, b_np, 1, 0, 1, 1, True)
+
+    print(f"{result}")
+    print(f"parallel: {result_parallel}") 
+


### PR DESCRIPTION
For now the benchmark result:
![Screenshot_20250402_234424](https://github.com/user-attachments/assets/24967ecc-f73c-4bde-86e4-9a6141e9d0da)

None of these AI frameworks could be better to pytorch. I haven't compare the IR of them yet.

I don't know which extent should we optimize these AI framework methods to. Conv2d is a very complicated operator, it will cost a significant time to optimize it with methods like tvm, autotvm or triton.