### PR TITLE
[cases] Add some implementations for conv2d; Completely refactor benchmark codes

### DIFF
--- a/cases/conv2d/BenchmarkConv2d.py
+++ b/cases/conv2d/BenchmarkConv2d.py
@@ -1,7 +1,15 @@
 from abc import ABC, abstractmethod
+from typing import Callable, List
 import numpy as np
+import numpy.typing as npt
 import time
-import config
+import torch
+import pandas as pd
+
+
+num_warmup = 200
+num_execution = 400
+benchmark_name = "conv2d"
 
 class BenchmarkConv2d(ABC):
 
@@ -11,33 +19,30 @@ class BenchmarkConv2d(ABC):
         self.parallel = False
 
     @abstractmethod
-    def process(self):
+    def process(self) -> npt.NDArray:
         pass
 
     @abstractmethod
-    def preprocess(self, x_np, w_np, b_np, stride, padding, dilation, groups):
+    def preprocess(self, x_np, w_np, b_np, stride, padding, dilation, groups) -> float:
+        """Return tuning time if tunable, else return 0"""
         pass
 
-    def execute(self):
-        """Helper function to execute operations"""
-        times = []
-        result = []
-        for _ in range(config.measurement_iterations):
-            start = time.perf_counter()
-            result = self.process()
-            end = time.perf_counter()
-            times.append(round((end - start) * 1000, 3))
+    @staticmethod
+    def measure(f: Callable, *args) -> float:
+        start = time.perf_counter()
+        f(*args)
+        end = time.perf_counter()
+        return round((end - start) * 1000, 3)
 
-        return np.mean(times[config.warmup_iterations:]), np.array(result), times[:config.warmup_iterations]
-
-    def benchmark(self, x_np, w_np, expected, b_np=None, stride=1, padding=0, dilation=1, groups=1, parallel=False):
+    def benchmark(self, x_np, w_np, expected, b_np=None, stride=1, padding=0, dilation=1, groups=1, parallel=True):
         """ Run benchmark
         Conventions:
-            Pass all arguments to `preprocess()` except `expected` and `parallel`, `preprocess()` will store result in `self`.
+            Pass all arguments to `preprocess()` except `expected` and `parallel`, `preprocess()` will store variables in `self`.
             Run the benchmark and return a dict for output
         Args:
             x_np: Input tensor of shape (batch_size, in_channels, in_height, in_width)
             w_np: Filter tensor of shape (out_channels, in_channels//groups, kernel_height, kernel_width)
+            expected: Expected result
             b_np: Optional bias tensor of shape (out_channels)
             stride: Int or tuple of (stride_h, stride_w). Default: 1
             padding: Int or tuple of (padding_h, padding_w). Default: 0
@@ -45,19 +50,65 @@ class BenchmarkConv2d(ABC):
             groups: Number of blocked connections from input to output channels. Default: 1
         """
         self.parallel = parallel
-        self.preprocess(x_np, w_np, b_np, stride, padding, dilation, groups)
+        print(f"  Running {self.name}...")
 
-        name=  self.name + ('_parallel' if parallel else '')
-        print(f"  Running {name}...")
-        exec_time, result, warmup_times = self.execute()
-
-        assert np.allclose(result, expected, atol=1e-3, rtol=1e-3), f"{name} result mismatch!"
+        tuning_time = self.preprocess(x_np, w_np, b_np, stride, padding, dilation, groups)
+        result = self.process()
+        assert np.allclose(result, expected, atol=1e-3, rtol=1e-3), f"{self.name} result mismatch!"
+        times = [self.measure(self.process) for _ in range(num_execution)]
+        # print(f"    {times}")
+        exec_time = np.mean(times[num_warmup:])
 
         return {
-            'Benchmark': config.benchmark,
+            'Benchmark': benchmark_name,
             'Shape': f"input: {x_np.shape}, out: {w_np.shape}",
-            'Method': name,
+            'Method': self.name,
             'Time(ms)': exec_time,
-            'WarmUpTimes(ms)': warmup_times
+            'TuningTime(ms)': tuning_time
         }
+
+def run_benchmarks(benchmarks: List[BenchmarkConv2d]):
+    configs = [
+        # (batch_size, channels_in, height, width, channels_out, kernel_size, stride, padding, dilation, groups)
+        (1, 3, 32, 32, 16, (3, 3), (1, 1), (1, 1), (1, 1), 1),
+        (1, 3, 64, 64, 32, (3, 3), (1, 1), (1, 1), (1, 1), 1),
+        (1, 64, 56, 56, 64, (3, 3), (1, 1), (1, 1), (1, 1), 1),
+        (8, 3, 224, 224, 64, (7, 7), (2, 2), (3, 3), (1, 1), 1),  # ResNet first layer
+    ]
+
+    records = []
+    for config in configs:
+        batch_size, channels_in, height, width, channels_out, kernel_size, stride, padding, dilation, groups = config
+
+        # Create input, weight, and bias tensors
+        x_np = np.random.rand(batch_size, channels_in, height, width).astype(np.float32)
+        w_np = np.random.rand(channels_out, channels_in // groups, kernel_size[0], kernel_size[1]).astype(np.float32)
+        b_np = np.random.rand(channels_out).astype(np.float32)
+
+        with torch.no_grad():
+            x_torch = torch.tensor(x_np, device='cpu')
+            w_torch = torch.tensor(w_np, device='cpu')
+            b_torch = torch.tensor(b_np, device='cpu')
+            expected = torch.nn.functional.conv2d(
+                x_torch, w_torch, b_torch, stride, padding, dilation, groups
+            ).numpy()
+
+        print(f"Benchmarking with input shape {x_np.shape}, weight shape {w_np.shape}")
+        for benchmark in benchmarks:
+            records.append(benchmark.benchmark(x_np, w_np, expected, b_np, stride, padding, dilation, groups))
+
+
+    # Create and save the benchmark results
+    df = pd.DataFrame(records)
+    df['Speedup'] = df.apply(
+        lambda row: round(df[
+        (df['Benchmark'] == row['Benchmark']) &
+        (df['Shape'] == row['Shape']) &
+        (df['Method'] == 'torch')
+        ]['Time(ms)'].values[0] / row['Time(ms)'], 3), axis=1
+    )
+    setattr(df, 'name', benchmark_name)
+    print(f"\nBenchmark Results:\n{df}")
+
+    return df
 

--- a/cases/conv2d/benchmark.py
+++ b/cases/conv2d/benchmark.py
@@ -1,4 +1,3 @@
-import time
 import torch
 import numpy as np
 import multiprocessing
@@ -6,6 +5,9 @@ import pandas as pd
 
 from BenchmarkConv2d import BenchmarkConv2d
 from conv2d_triton import BenchmarkConv2dTriton
+from conv2d_tvm import BenchmarkConv2dTVM, BenchmarkConv2dTVMO1
+from conv2d_hidet import BenchmarkConv2dHidet
+from conv2d_ansor import BenchmarkConv2dAnsor
 import config
 
 class BenchmarkConv2dTorch(BenchmarkConv2d):
@@ -60,6 +62,10 @@ def main():
         benchmarks: list[BenchmarkConv2d] = [
             BenchmarkConv2dTorch(),
             BenchmarkConv2dTriton(),
+            BenchmarkConv2dTVM(),
+            BenchmarkConv2dTVMO1(),
+            BenchmarkConv2dHidet(),
+            BenchmarkConv2dAnsor()
         ]
 
         print(f"Benchmarking with input shape {x_np.shape}, weight shape {w_np.shape}")
@@ -72,7 +78,6 @@ def main():
     df = pd.DataFrame(records)
     df["Time(ms)"] = df["Time(ms)"].apply(lambda x: round(x, 3))
     df["WarmUpTimes(ms)"] = df["WarmUpTimes(ms)"].apply(lambda x: ', '.join(f"{t:.3f}" for t in x))
-    df = df.sort_values(by=["Shape"])
     print("\nBenchmark Results:")
     print(df)
     df.to_csv(f"./{config.benchmark}_performance_report.csv", index=False)

--- a/cases/conv2d/benchmark.py
+++ b/cases/conv2d/benchmark.py
@@ -1,14 +1,11 @@
 import torch
-import numpy as np
 import multiprocessing
-import pandas as pd
 
-from BenchmarkConv2d import BenchmarkConv2d
+from BenchmarkConv2d import BenchmarkConv2d, run_benchmarks
 from conv2d_triton import BenchmarkConv2dTriton
-from conv2d_tvm import BenchmarkConv2dTVM, BenchmarkConv2dTVMO1
+from conv2d_tvm import BenchmarkConv2dTVM
 from conv2d_hidet import BenchmarkConv2dHidet
 from conv2d_ansor import BenchmarkConv2dAnsor
-import config
 
 class BenchmarkConv2dTorch(BenchmarkConv2d):
 
@@ -29,58 +26,32 @@ class BenchmarkConv2dTorch(BenchmarkConv2d):
         self.dilation = dilation
         self.groups = groups
 
+        return 0.0
+
     def process(self):
         with torch.no_grad():
-            return torch.nn.functional.conv2d(self.input, self.weight, self.bias, self.stride, self.padding, self.dilation, self.groups)
+            return torch.nn.functional.conv2d(self.input, self.weight, self.bias, self.stride, self.padding, self.dilation, self.groups).numpy()
+
+benchmarks = [
+    BenchmarkConv2dTorch(),
+    BenchmarkConv2dTriton(),
+    BenchmarkConv2dTVM(),
+    BenchmarkConv2dHidet(),
+    BenchmarkConv2dAnsor()
+]
 
 def main():
-    configs = [
-        # (batch_size, channels_in, height, width, channels_out, kernel_size, stride, padding, dilation, groups)
-        (1, 3, 32, 32, 16, (3, 3), (1, 1), (1, 1), (1, 1), 1),
-        (1, 3, 64, 64, 32, (3, 3), (1, 1), (1, 1), (1, 1), 1),
-        (1, 64, 56, 56, 64, (3, 3), (1, 1), (1, 1), (1, 1), 1),
-        (8, 3, 224, 224, 64, (7, 7), (2, 2), (3, 3), (1, 1), 1),  # ResNet first layer
-    ]
-    records = []
-
-    for config_conv2d in configs:
-        batch_size, channels_in, height, width, channels_out, kernel_size, stride, padding, dilation, groups = config_conv2d
-
-        # Create input, weight, and bias tensors
-        x_np = np.random.rand(batch_size, channels_in, height, width).astype(np.float32)
-        w_np = np.random.rand(channels_out, channels_in // groups, kernel_size[0], kernel_size[1]).astype(np.float32)
-        b_np = np.random.rand(channels_out).astype(np.float32)
-
-        with torch.no_grad():
-            x_torch = torch.tensor(x_np, device='cpu')
-            w_torch = torch.tensor(w_np, device='cpu')
-            b_torch = torch.tensor(b_np, device='cpu')
-            expected = torch.nn.functional.conv2d(
-                x_torch, w_torch, b_torch, stride, padding, dilation, groups
-            ).numpy()
-
-        benchmarks: list[BenchmarkConv2d] = [
-            BenchmarkConv2dTorch(),
-            BenchmarkConv2dTriton(),
-            BenchmarkConv2dTVM(),
-            BenchmarkConv2dTVMO1(),
-            BenchmarkConv2dHidet(),
-            BenchmarkConv2dAnsor()
-        ]
-
-        print(f"Benchmarking with input shape {x_np.shape}, weight shape {w_np.shape}")
-        for benchmark in benchmarks:
-            records.append(benchmark.benchmark(x_np, w_np, expected, b_np, stride, padding, dilation, groups, False))
-            if config.benchmark_parallel and benchmark.parallelable:
-                records.append(benchmark.benchmark(x_np, w_np, expected, b_np, stride, padding, dilation, groups, True))
-
-    # Create and save the benchmark results
-    df = pd.DataFrame(records)
-    df["Time(ms)"] = df["Time(ms)"].apply(lambda x: round(x, 3))
-    df["WarmUpTimes(ms)"] = df["WarmUpTimes(ms)"].apply(lambda x: ', '.join(f"{t:.3f}" for t in x))
-    print("\nBenchmark Results:")
-    print(df)
-    df.to_csv(f"./{config.benchmark}_performance_report.csv", index=False)
+    df = run_benchmarks(benchmarks)
+    df['Speedup'] = df.apply(
+        lambda row: round(df[
+        (df['Benchmark'] == row['Benchmark']) &
+        (df['Shape'] == row['Shape']) &
+        (df['Method'] == 'torch')
+        ]['Time(ms)'].values[0] / row['Time(ms)'], 3), axis=1
+    )
+    print(f"\nBenchmark Results:\n{df}")
+    df.to_csv(f"./{getattr(df, 'name')}_performance_report.csv", index=False)
 
 if __name__ == "__main__":
-    main() 
+    main()
+

--- a/cases/conv2d/config.py
+++ b/cases/conv2d/config.py
@@ -1,4 +1,0 @@
-benchmark = "transpose"
-warmup_iterations = 5  # Warmup iterations before timing
-measurement_iterations = 10  # Number of iterations for measurement
-benchmark_parallel = True

--- a/cases/conv2d/conv2d_ansor.py
+++ b/cases/conv2d/conv2d_ansor.py
@@ -1,0 +1,87 @@
+import numpy as np
+import torch
+import tvm
+from tvm import te, topi
+from tvm import auto_scheduler
+from BenchmarkConv2d import BenchmarkConv2d
+
+@auto_scheduler.register_workload
+def conv2d(input_shape, weight_shape, has_bias, stride, padding, dilation, groups, dtype):
+    data = te.placeholder(input_shape, name="data", dtype=dtype)
+    kernel = te.placeholder(weight_shape, name="kernel", dtype=dtype)
+    out = topi.nn.conv(data, kernel, stride, padding, dilation, groups, "NCHW", out_dtype=dtype)
+    if has_bias:
+        bias = te.placeholder((weight_shape[0],), name="bias", dtype=dtype)
+        out = topi.add(out, topi.reshape(bias, (1, weight_shape[0], 1, 1)))
+        return [data, kernel, bias, out]
+    return [data, kernel, out]
+
+class BenchmarkConv2dAnsor(BenchmarkConv2d):
+
+    def __init__(self):
+        super().__init__('tvm_ansor', False)
+
+    def preprocess(self, x_np, w_np, b_np, stride, padding, dilation, groups):
+        stride = (stride, stride) if isinstance(stride, int) else stride
+        padding = (padding, padding) if isinstance(padding, int) else padding
+        dilation = (dilation, dilation) if isinstance(dilation, int) else dilation
+        self.has_bias = b_np is not None
+
+        target = tvm.target.Target("llvm")
+        task = auto_scheduler.SearchTask(
+            func=conv2d,
+            args=(x_np.shape, w_np.shape, self.has_bias, stride, padding, dilation, groups, str(x_np.dtype)),
+            target=target
+        )
+
+        # print("Computational DAG for conv2d auto_scheduler:")
+        # print(task.compute_dag)
+
+        log_file = "conv2d-auto_scheduler.json"
+        tune_option = auto_scheduler.TuningOptions(
+            num_measure_trials=10, # TODO: How many trials will be good?
+            measure_callbacks=[auto_scheduler.RecordToFile(log_file)],
+            verbose=2,
+        )
+
+        task.tune(tune_option)
+        sch, args = task.apply_best(log_file)
+        self.func = tvm.build(sch, args, "llvm")
+
+        # print("Lowered TIR:")
+        # print(tvm.lower(sch, args, simple_mode=True))
+
+        # prepare tvm tensors
+        self.input_tvm = tvm.nd.array(x_np, device=tvm.cpu())
+        self.weight_tvm = tvm.nd.array(w_np, device=tvm.cpu())
+        self.bias_tvm = tvm.nd.array(b_np, device=tvm.cpu()) if self.has_bias else None
+
+        out_height = (x_np.shape[2] + 2 * padding[0] - dilation[0] * (w_np.shape[2] - 1) - 1) // stride[0] + 1
+        out_width = (x_np.shape[3] + 2 * padding[1] - dilation[1] * (w_np.shape[3] - 1) - 1) // stride[1] + 1
+        self.out_tvm = tvm.nd.empty((x_np.shape[0], w_np.shape[0], out_height, out_width))
+
+    def process(self):
+        if self.has_bias:
+            self.func(self.input_tvm, self.weight_tvm, self.bias_tvm, self.out_tvm)
+        else:
+            self.func(self.input_tvm, self.weight_tvm, self.out_tvm)
+        return self.out_tvm.numpy()
+
+
+if __name__ == "__main__":
+    batch_size, in_channels, in_height, in_width = 1, 3, 32, 32
+    out_channels, kernel_height, kernel_width = 16, 3, 3
+
+    x_np = np.random.rand(batch_size, in_channels, in_height, in_width).astype(np.float32)
+    w_np = np.random.rand(out_channels, in_channels, kernel_height, kernel_width).astype(np.float32)
+    b_np = np.random.rand(out_channels).astype(np.float32)
+
+    x_torch = torch.tensor(x_np, dtype=torch.float32)
+    w_torch = torch.tensor(w_np, dtype=torch.float32)
+    b_torch = torch.tensor(b_np, dtype=torch.float32)
+    expected = torch.nn.functional.conv2d(x_torch, w_torch, b_torch).numpy()
+
+    benchmark = BenchmarkConv2dAnsor()
+    result = benchmark.benchmark(x_np, w_np, expected, b_np, 1, 0, 1, 1, False)
+    print(f"{result}")
+

--- a/cases/conv2d/conv2d_hidet.py
+++ b/cases/conv2d/conv2d_hidet.py
@@ -1,0 +1,67 @@
+# Hidet Benchmark
+# Refer to: https://hidet.org/docs/stable/python_api/ops/index.html
+
+import numpy as np
+import torch
+import hidet
+from BenchmarkConv2d import BenchmarkConv2d
+
+
+class BenchmarkConv2dHidet(BenchmarkConv2d):
+
+    def __init__(self):
+        super().__init__('hidet', False)
+
+    def preprocess(self, x_np, w_np, b_np, stride, padding, dilation, groups):
+        hidet.option.cache_dir('./.hidet/cache')
+
+        # Convert NumPy arrays to Hidet tensors
+        self.input = hidet.graph.from_numpy(x_np)
+        self.weight = hidet.graph.from_numpy(w_np)
+        self.bias = hidet.graph.from_numpy(b_np) if b_np is not None else None
+
+        # Store the convolution parameters
+        self.stride = stride
+        self.padding = padding
+        self.dilation = dilation
+        self.groups = groups
+
+    def process(self):
+        # Execute the convolution operation
+        output = hidet.ops.conv2d(
+            self.input, 
+            self.weight,
+            stride=self.stride,
+            padding=self.padding,
+            dilations=self.dilation,
+            groups=self.groups
+        )
+
+        # Add bias manually if it exists
+        if self.bias is not None:
+            output = output + self.bias.reshape((1, -1, 1, 1))  # Ensure proper broadcasting
+
+        return output.numpy()
+
+
+if __name__ == "__main__":
+    # Test the convolution with a simple example
+    batch_size, in_channels, in_height, in_width = 1, 3, 32, 32
+    out_channels, kernel_height, kernel_width = 16, 3, 3
+
+    x_np = np.random.rand(batch_size, in_channels, in_height, in_width).astype(np.float32)
+    w_np = np.random.rand(out_channels, in_channels, kernel_height, kernel_width).astype(np.float32)
+    b_np = np.random.rand(out_channels).astype(np.float32)
+
+    # Verify with PyTorch
+    x_torch = torch.tensor(x_np, dtype=torch.float32)
+    w_torch = torch.tensor(w_np, dtype=torch.float32)
+    b_torch = torch.tensor(b_np, dtype=torch.float32)
+    expected = torch.nn.functional.conv2d(x_torch, w_torch, b_torch).numpy()
+
+    # Test with Hidet
+    benchmark = BenchmarkConv2dHidet()
+    result = benchmark.benchmark(x_np, w_np, expected, b_np, 1, 0, 1, 1, False)
+
+    print(f"{result}")
+

--- a/cases/conv2d/conv2d_hidet.py
+++ b/cases/conv2d/conv2d_hidet.py
@@ -1,19 +1,13 @@
-# Hidet Benchmark
-# Refer to: https://hidet.org/docs/stable/python_api/ops/index.html
-
-import numpy as np
-import torch
 import hidet
-from BenchmarkConv2d import BenchmarkConv2d
+from BenchmarkConv2d import BenchmarkConv2d, run_benchmarks
 
 
 class BenchmarkConv2dHidet(BenchmarkConv2d):
-
     def __init__(self):
-        super().__init__('hidet', False)
+        super().__init__("hidet", False)
 
     def preprocess(self, x_np, w_np, b_np, stride, padding, dilation, groups):
-        hidet.option.cache_dir('./.hidet/cache')
+        hidet.option.cache_dir("./.hidet/cache")
 
         # Convert NumPy arrays to Hidet tensors
         self.input = hidet.graph.from_numpy(x_np)
@@ -25,43 +19,30 @@ class BenchmarkConv2dHidet(BenchmarkConv2d):
         self.padding = padding
         self.dilation = dilation
         self.groups = groups
+        return 0.0
 
     def process(self):
         # Execute the convolution operation
         output = hidet.ops.conv2d(
-            self.input, 
+            self.input,
             self.weight,
             stride=self.stride,
             padding=self.padding,
             dilations=self.dilation,
-            groups=self.groups
+            groups=self.groups,
         )
 
         # Add bias manually if it exists
         if self.bias is not None:
-            output = output + self.bias.reshape((1, -1, 1, 1))  # Ensure proper broadcasting
+            output = output + self.bias.reshape(
+                (1, -1, 1, 1)
+            )  # Ensure proper broadcasting
 
         return output.numpy()
 
 
 if __name__ == "__main__":
-    # Test the convolution with a simple example
-    batch_size, in_channels, in_height, in_width = 1, 3, 32, 32
-    out_channels, kernel_height, kernel_width = 16, 3, 3
-
-    x_np = np.random.rand(batch_size, in_channels, in_height, in_width).astype(np.float32)
-    w_np = np.random.rand(out_channels, in_channels, kernel_height, kernel_width).astype(np.float32)
-    b_np = np.random.rand(out_channels).astype(np.float32)
-
-    # Verify with PyTorch
-    x_torch = torch.tensor(x_np, dtype=torch.float32)
-    w_torch = torch.tensor(w_np, dtype=torch.float32)
-    b_torch = torch.tensor(b_np, dtype=torch.float32)
-    expected = torch.nn.functional.conv2d(x_torch, w_torch, b_torch).numpy()
-
-    # Test with Hidet
     benchmark = BenchmarkConv2dHidet()
-    result = benchmark.benchmark(x_np, w_np, expected, b_np, 1, 0, 1, 1, False)
-
-    print(f"{result}")
+    df = run_benchmarks([benchmark])
+    print(f"\nBenchmark Results:\n{df}")
 

--- a/cases/conv2d/conv2d_triton.py
+++ b/cases/conv2d/conv2d_triton.py
@@ -1,24 +1,29 @@
 # ref: https://github.com/FlagOpen/FlagGems/blob/master/src/flag_gems/ops/conv2d.py
 
 import torch
-import numpy as np
 import triton
 import triton.language as tl
 import os
 
-from BenchmarkConv2d import BenchmarkConv2d
+from BenchmarkConv2d import BenchmarkConv2d, run_benchmarks
+
 
 def get_configs():
     configs = []
-    for BLOCK_NI_HO_WO in [4, 8, 32]:
-        for BLOCK_CI in [4, 8, 16, 32, 64]:
-            for BLOCK_CO in [4, 8, 16]:
-                configs.append(triton.Config({
-                    'BLOCK_NI_HO_WO': BLOCK_NI_HO_WO,
-                    'BLOCK_CI': BLOCK_CI,
-                    'BLOCK_CO': BLOCK_CO,
-                }))
+    for BLOCK_NI_HO_WO in [8, 32, 64]:
+        for BLOCK_CI in [4, 16, 32]:
+            for BLOCK_CO in [16, 32, 64]:
+                configs.append(
+                    triton.Config(
+                        {
+                            "BLOCK_NI_HO_WO": BLOCK_NI_HO_WO,
+                            "BLOCK_CI": BLOCK_CI,
+                            "BLOCK_CO": BLOCK_CO,
+                        }
+                    )
+                )
     return configs
+
 
 def conv2d_output_size(
     in_size: int,
@@ -41,6 +46,7 @@ def conv2d_output_size(
         Output size of 2D convolution.
     """
     return (in_size + 2 * padding - dilation * (kernel_size - 1) - 1) // stride + 1
+
 
 @triton.autotune(
     configs=get_configs(),
@@ -70,9 +76,8 @@ def conv2d_kernel(
     weight_n_stride, weight_c_stride, weight_height_stride, weight_width_stride,
     output_n_stride, output_c_stride, output_height_stride, output_width_stride,
     weight_c: tl.constexpr, weight_height: tl.constexpr, weight_width: tl.constexpr,
-    stride_height: tl.constexpr, stride_width: tl.constexpr,
-    padding_height: tl.constexpr, padding_width: tl.constexpr,
-    dilation_height: tl.constexpr, dilation_width: tl.constexpr,
+    stride_height: tl.constexpr, stride_width: tl.constexpr, padding_height: tl.constexpr,
+    padding_width: tl.constexpr, dilation_height: tl.constexpr, dilation_width: tl.constexpr,
     groups: tl.constexpr,
     BLOCK_NI_HO_WO: tl.constexpr, BLOCK_CI: tl.constexpr, BLOCK_CO: tl.constexpr,
 ):
@@ -80,41 +85,41 @@ def conv2d_kernel(
     pid_ni_ho_wo = tl.program_id(0)  # Batch * output height * output width
     pid_co = tl.program_id(1)  # Output channels
     pid_group = tl.program_id(2)  # Group
-    
+
     # Calculate batch, height, width indices
     ni_ho_wo_offset = pid_ni_ho_wo * BLOCK_NI_HO_WO + tl.arange(0, BLOCK_NI_HO_WO)
     ni_ho_offset = ni_ho_wo_offset // out_width
     in_n_point_value = ni_ho_offset // out_height
     output_height_point_value = ni_ho_offset % out_height
     output_width_point_value = ni_ho_wo_offset % out_width
-    
+
     # Calculate channel offsets based on groups
     out_per_group_c = out_c // groups
     output_c_offset = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
-    
+
     # Adjust input and weight pointers for group
     input_pointer += (
         input_n_stride * in_n_point_value + input_c_stride * pid_group * weight_c
     )[:, None]
-    
+
     weight_pointer += (
         weight_n_stride * output_c_offset
         + weight_n_stride * pid_group * out_per_group_c
     )[None, :]
-    
+
     # Initialize accumulators
     accum = tl.zeros((BLOCK_NI_HO_WO, BLOCK_CO), dtype=tl.float32)
-    
+
     # Compute how many channel blocks we need
     BLOCK_CI_COUNT = (weight_c + BLOCK_CI - 1) // BLOCK_CI
-    
+
     # Loop over input channels and kernel dimensions
     for hwc in range(weight_height * weight_width * BLOCK_CI_COUNT):
         c = (hwc % BLOCK_CI_COUNT) * BLOCK_CI
         hw = hwc // BLOCK_CI_COUNT
         h = hw // weight_width
         w = hw % weight_width
-        
+
         # Calculate offsets
         input_c_offset = c + tl.arange(0, BLOCK_CI)
         input_height_offset = (
@@ -123,11 +128,9 @@ def conv2d_kernel(
             + stride_height * output_height_point_value
         )
         input_width_offset = (
-            w * dilation_width 
-            - padding_width 
-            + stride_width * output_width_point_value
+            w * dilation_width - padding_width + stride_width * output_width_point_value
         )
-        
+
         # Calculate current pointers
         curr_input_pointer = (
             input_pointer
@@ -135,14 +138,14 @@ def conv2d_kernel(
             + (input_height_stride * input_height_offset)[:, None]
             + (input_width_stride * input_width_offset)[:, None]
         )
-        
+
         curr_weight_pointer = (
             weight_pointer
             + (weight_c_stride * input_c_offset)[:, None]
             + (weight_height_stride * h)
             + (weight_width_stride * w)
         )
-        
+
         # Create masks for valid elements
         input_mask = (
             (in_n_point_value < in_n)[:, None]
@@ -152,25 +155,27 @@ def conv2d_kernel(
             & (0 <= input_width_offset)[:, None]
             & (input_width_offset < input_width)[:, None]
         )
-        
+
         weight_mask = (input_c_offset < weight_c)[:, None] & (
             output_c_offset < out_per_group_c
         )[None, :]
-        
+
         # Load input and weight values
         input_block = tl.load(curr_input_pointer, mask=input_mask, other=0.0)
         weight_block = tl.load(curr_weight_pointer, mask=weight_mask, other=0.0)
-        
+
         # Compute matrix multiplication
         accum += tl.dot(input_block, weight_block)
-    
+
     # Add bias if available
     if bias_pointer is not None:
-        bias_ptr = bias_pointer + (pid_group * out_per_group_c + output_c_offset)[None, :]
+        bias_ptr = (
+            bias_pointer + (pid_group * out_per_group_c + output_c_offset)[None, :]
+        )
         mask_bias = (output_c_offset < out_per_group_c)[None, :]
         bias = tl.load(bias_ptr, mask=mask_bias, other=0.0).to(tl.float32)
         accum += bias
-    
+
     # Calculate output pointers
     output_pointer += (
         (output_n_stride * in_n_point_value)[:, None]
@@ -178,7 +183,7 @@ def conv2d_kernel(
         + (output_height_stride * output_height_point_value)[:, None]
         + (output_width_stride * output_width_point_value)[:, None]
     )
-    
+
     # Create mask for valid output elements
     output_mask = (
         (in_n_point_value < in_n)[:, None]
@@ -186,107 +191,96 @@ def conv2d_kernel(
         & (output_height_point_value < out_height)[:, None]
         & (output_width_point_value < out_width)[:, None]
     )
-    
+
     # Store the results
     tl.store(output_pointer, accum, mask=output_mask)
 
-class BenchmarkConv2dTriton(BenchmarkConv2d):
 
+class BenchmarkConv2dTriton(BenchmarkConv2d):
     def __init__(self):
-        super().__init__('triton', True)
+        super().__init__("triton", True)
 
     def preprocess(self, x_np, w_np, b_np, stride, padding, dilation, groups):
         os.environ["TRITON_CPU_BACKEND"] = "1"
         os.environ["TRITON_CPU_MAX_THREADS"] = "0" if self.parallel else "1"
 
-        self.input = torch.tensor(x_np, device='cpu', dtype=torch.float32)
-        self.weight = torch.tensor(w_np, device='cpu', dtype=torch.float32)
-        self.bias = torch.tensor(b_np, device='cpu', dtype=torch.float32) if b_np is not None else None
+        self.input = torch.tensor(x_np, device="cpu", dtype=torch.float32)
+        self.weight = torch.tensor(w_np, device="cpu", dtype=torch.float32)
+        self.bias = (
+            torch.tensor(b_np, device="cpu", dtype=torch.float32)
+            if b_np is not None
+            else None
+        )
         self.groups = groups
 
         self.stride = (stride, stride) if isinstance(stride, int) else stride
         self.padding = (padding, padding) if isinstance(padding, int) else padding
         self.dilation = (dilation, dilation) if isinstance(dilation, int) else dilation
 
-        assert self.input.shape[1] % self.groups == 0, "in_channels must be divisible by groups"
-        assert self.weight.shape[0] % self.groups == 0, "out_channels must be divisible by groups"
-        assert self.input.shape[1] // self.groups == self.weight.shape[1], "Invalid filter dimensions for groups"
+        batch_size, in_channels, in_height, in_width = x_np.shape
+        out_channels, in_channels_per_group, kernel_height, kernel_width = w_np.shape
 
-    def process(self):
-        batch_size, in_channels, in_height, in_width = self.input.shape
-        out_channels, in_channels_per_group, kernel_height, kernel_width = self.weight.shape
+        assert in_channels % self.groups == 0, "in_channels must be divisible by groups"
+        assert out_channels % self.groups == 0, ("out_channels must be divisible by groups")
+        assert in_channels // self.groups == in_channels_per_group, ("Invalid filter dimensions for groups")
 
-        stride_h, stride_w = self.stride
-        padding_h, padding_w = self.padding
-        dilation_h, dilation_w = self.dilation
+        self.out_height = conv2d_output_size(
+            in_height, kernel_height, self.stride[0], self.padding[0], self.dilation[0]
+        )
+        self.out_width = conv2d_output_size(
+            in_width, kernel_width, self.stride[1], self.padding[1], self.dilation[1]
+        )
 
-        out_height = conv2d_output_size(in_height, kernel_height, stride_h, padding_h, dilation_h)
-        out_width = conv2d_output_size(in_width, kernel_width, stride_w, padding_w, dilation_w)
-
-        output = torch.zeros((batch_size, out_channels, out_height, out_width), 
-                            dtype=self.input.dtype, device=self.input.device)
+        self.output = torch.zeros(
+            (batch_size, out_channels, self.out_height, self.out_width),
+            dtype=self.input.dtype,
+            device=self.input.device,
+        )
 
         # Create grid dimensions: (batch*height*width blocks, output channel blocks, groups)
-        grid = lambda META: (
-            triton.cdiv(batch_size * out_height * out_width, META["BLOCK_NI_HO_WO"]),
+        self.grid = lambda META: (
+            triton.cdiv(
+                batch_size * self.out_height * self.out_width, META["BLOCK_NI_HO_WO"]
+            ),
             triton.cdiv(out_channels // self.groups, META["BLOCK_CO"]),
             self.groups,
         )
 
+        # for debug
+        self.already_print = False
+
+        return self.measure(self.process)
+
+    def process(self):
+        batch_size, _, in_height, in_width = self.input.shape
+        out_channels, in_channels_per_group, kernel_height, kernel_width = (
+            self.weight.shape
+        )
+
         # Launch the kernel
-        conv2d_kernel[grid](
-            self.input,
-            self.weight,
-            output,
-            self.bias,
-            batch_size,
-            in_height,
-            in_width,
-            out_channels,
-            out_height,
-            out_width,
+        conv2d_kernel[self.grid](
+            self.input, self.weight, self.output, self.bias,
+            batch_size, in_height, in_width, out_channels,
+            self.out_height, self.out_width,
             self.input.stride(0), self.input.stride(1), self.input.stride(2), self.input.stride(3),
             self.weight.stride(0), self.weight.stride(1), self.weight.stride(2), self.weight.stride(3),
-            output.stride(0), output.stride(1), output.stride(2), output.stride(3),
-            in_channels_per_group,
-            kernel_height,
-            kernel_width,
-            stride_h,
-            stride_w,
-            padding_h,
-            padding_w,
-            dilation_h,
-            dilation_w,
+            self.output.stride(0), self.output.stride(1), self.output.stride(2), self.output.stride(3),
+            in_channels_per_group, kernel_height, kernel_width,
+            self.stride[0], self.stride[1],
+            self.padding[0], self.padding[1],
+            self.dilation[0], self.dilation[1],
             self.groups,
         )
-        # print(f"Best config: {conv2d_kernel.best_config}")
-        
-        return output
+
+        if not self.already_print:
+            print(f"    Best config: {conv2d_kernel.best_config}")
+            self.already_print = True
+
+        return self.output.numpy()
 
 
 if __name__ == "__main__":
-    # Test the convolution with a simple example
-    batch_size, in_channels, in_height, in_width = 1, 3, 32, 32
-    out_channels, kernel_height, kernel_width = 16, 3, 3
-    
-    x_np = np.random.rand(batch_size, in_channels, in_height, in_width).astype(np.float32)
-    w_np = np.random.rand(out_channels, in_channels, kernel_height, kernel_width).astype(np.float32)
-    b_np = np.random.rand(out_channels).astype(np.float32)
-    
-    # Test without bias
     benchmark = BenchmarkConv2dTriton()
-    time_triton, result_triton, warmup_times= benchmark.benchmark(x_np, w_np, b_np, False)
-    time_triton_parallel, result_triton_parallel, warpup_times_parallel = benchmark.benchmark(x_np, w_np, b_np, True)
-    
-    # Verify with PyTorch
-    x_torch = torch.tensor(x_np, dtype=torch.float32)
-    w_torch = torch.tensor(w_np, dtype=torch.float32)
-    b_torch = torch.tensor(b_np, dtype=torch.float32)
-    expected = torch.nn.functional.conv2d(x_torch, w_torch, b_torch).numpy()
-    
-    assert np.allclose(result_triton, expected, atol=1e-3, rtol=1e-3), "Triton result mismatch!"
-    assert np.allclose(result_triton_parallel, expected, atol=1e-3, rtol=1e-3), "Triton parallel result mismatch!"
-    
-    print(f"Triton single: {time_triton} ms (tuning: {warmup_times} ms)")
-    print(f"Triton parallel: {time_triton_parallel} ms (tuning: {warpup_times_parallel} ms)")
+    df = run_benchmarks([benchmark])
+    print(f"\nBenchmark Results:\n{df}")
 

--- a/cases/conv2d/conv2d_triton.py
+++ b/cases/conv2d/conv2d_triton.py
@@ -6,15 +6,13 @@ import triton
 import triton.language as tl
 import os
 
-from config import measurement_iterations, warmup_iterations
-
 from BenchmarkConv2d import BenchmarkConv2d
 
 def get_configs():
     configs = []
-    for BLOCK_NI_HO_WO in [32, 64, 128]:
-        for BLOCK_CI in [16, 32]:
-            for BLOCK_CO in [16, 32, 64]:
+    for BLOCK_NI_HO_WO in [4, 8, 32]:
+        for BLOCK_CI in [4, 8, 16, 32, 64]:
+            for BLOCK_CO in [4, 8, 16]:
                 configs.append(triton.Config({
                     'BLOCK_NI_HO_WO': BLOCK_NI_HO_WO,
                     'BLOCK_CI': BLOCK_CI,
@@ -261,6 +259,7 @@ class BenchmarkConv2dTriton(BenchmarkConv2d):
             dilation_w,
             self.groups,
         )
+        # print(f"Best config: {conv2d_kernel.best_config}")
         
         return output
 

--- a/cases/conv2d/conv2d_tvm.py
+++ b/cases/conv2d/conv2d_tvm.py
@@ -1,11 +1,6 @@
-# TVM Benchmark
-# Refer to: https://tvm.apache.org/docs/reference/api/python/topi.html#tvm.topi.nn.conv2d
-
-import numpy as np
-import torch
 import tvm
 from tvm import te, topi
-from BenchmarkConv2d import BenchmarkConv2d
+from BenchmarkConv2d import BenchmarkConv2d, run_benchmarks
 
 
 class BenchmarkConv2dTVM(BenchmarkConv2d):
@@ -14,225 +9,47 @@ class BenchmarkConv2dTVM(BenchmarkConv2d):
         super().__init__('tvm', True)
 
     def preprocess(self, x_np, w_np, b_np, stride, padding, dilation, groups):
-        self.input_shape = x_np.shape
-        self.weight_shape = w_np.shape
         self.dtype = str(x_np.dtype)
+        stride = (stride, stride) if isinstance(stride, int) else stride
+        padding = (padding, padding) if isinstance(padding, int) else padding
+        dilation = (dilation, dilation) if isinstance(dilation, int) else dilation
+        self.has_bias = b_np is not None
 
-        # Convert to TVM tensors
+        input = te.placeholder(x_np.shape, name='A', dtype=self.dtype)
+        weight = te.placeholder(w_np.shape, name='W', dtype=self.dtype)
+        out = topi.nn.conv(input, weight, stride, padding, dilation, groups, "NCHW", out_dtype=self.dtype)
+        bias = None
+        if self.has_bias:
+            bias = te.placeholder((weight.shape[0],), name="bias", dtype=self.dtype)
+            out = topi.add(out, topi.reshape(bias, (1, weight.shape[0], 1, 1)))
+        s = te.create_schedule(out.op)
+
+        # prepare tvm tensors
         self.input_tvm = tvm.nd.array(x_np, device=tvm.cpu())
         self.weight_tvm = tvm.nd.array(w_np, device=tvm.cpu())
-        self.bias_tvm = tvm.nd.array(b_np, device=tvm.cpu()) if b_np is not None else None
+        self.bias_tvm = tvm.nd.array(b_np, device=tvm.cpu()) if self.has_bias else None
 
-        # Handle parameter formats
-        self.stride = (stride, stride) if isinstance(stride, int) else stride
-        self.padding = (padding, padding) if isinstance(padding, int) else padding
-        self.dilation = (dilation, dilation) if isinstance(dilation, int) else dilation
-        self.groups = groups
+        out_height = (x_np.shape[2] + 2 * padding[0] - dilation[0] * (w_np.shape[2] - 1) - 1) // stride[0] + 1
+        out_width = (x_np.shape[3] + 2 * padding[1] - dilation[1] * (w_np.shape[3] - 1) - 1) // stride[1] + 1
+        self.out_tvm = tvm.nd.empty((x_np.shape[0], w_np.shape[0], out_height, out_width))
 
-        # Create placeholders for the computation
-        batch_size, in_channels, in_height, in_width = x_np.shape
-        out_channels, in_channels_per_group, kernel_height, kernel_width = w_np.shape
-
-        # Create input and weight tensors
-        A = te.placeholder((batch_size, in_channels, in_height, in_width), name='A', dtype=self.dtype)
-        W = te.placeholder((out_channels, in_channels_per_group, kernel_height, kernel_width), name='W', dtype=self.dtype)
-
-        # Define the convolution computation
-        stride_h, stride_w = self.stride
-        padding_h, padding_w = self.padding
-        dilation_h, dilation_w = self.dilation
-
-        # Compute output dimensions
-        out_height = (in_height + 2 * padding_h - dilation_h * (kernel_height - 1) - 1) // stride_h + 1
-        out_width = (in_width + 2 * padding_w - dilation_w * (kernel_width - 1) - 1) // stride_w + 1
-
-        if groups == 1:
-            # Standard convolution
-            B = topi.nn.conv2d(A, W, strides=self.stride, padding=self.padding, dilation=self.dilation, out_dtype=self.dtype)
-        else:
-            # Split input and weights into `groups` and perform grouped convolution
-            A_splits = te.compute((groups, batch_size, in_channels // groups, in_height, in_width), lambda g, n, c, h, w: A[n, g * (in_channels // groups) + c, h, w], name="A_splits")
-            W_splits = te.compute((groups, out_channels // groups, in_channels // groups, kernel_height, kernel_width), lambda g, oc, ic, kh, kw: W[g * (out_channels // groups) + oc, ic, kh, kw], name="W_splits")
-
-            B_splits = [topi.nn.conv2d(A_splits[g], W_splits[g], strides=self.stride, padding=self.padding, dilation=self.dilation, out_dtype=self.dtype) for g in range(groups)]
-
-            B = topi.concatenate(B_splits, axis=1)  # Concatenate along the channel dimension
-
-        # Add bias if provided
-        if b_np is not None:
-            bias = te.placeholder((out_channels,), name='bias', dtype=self.dtype)
-            B = topi.add(B, topi.reshape(bias, (1, out_channels, 1, 1)))
-            self.has_bias = True
-        else:
-            self.has_bias = False
-
-        s = te.create_schedule(B.op)
-
-        # Apply parallelization if needed
-        if self.parallel:
-            output_op = s[B].op
-            if isinstance(output_op, tvm.te.ComputeOp):
-                n, f, y, x = output_op.axis
-                s[B].parallel(n)
-
-        # Build the function
         if self.has_bias:
-            self.func = tvm.build(s, [A, W, bias, B], target="llvm", name="conv2d")
-            self.output_tvm = tvm.nd.empty((batch_size, out_channels, out_height, out_width), 
-                                        dtype=self.dtype, device=tvm.cpu())
+            self.func = tvm.build(s, [input, weight, bias, out])
         else:
-            self.func = tvm.build(s, [A, W, B], target="llvm", name="conv2d")
-            self.output_tvm = tvm.nd.empty((batch_size, out_channels, out_height, out_width), 
-                                        dtype=self.dtype, device=tvm.cpu())
+            self.func = tvm.build(s, [input, weight, out])
+
+        return 0.0
 
     def process(self):
-        # Execute the function
         if self.has_bias:
-            self.func(self.input_tvm, self.weight_tvm, self.bias_tvm, self.output_tvm)
+            self.func(self.input_tvm, self.weight_tvm, self.bias_tvm, self.out_tvm)
         else:
-            self.func(self.input_tvm, self.weight_tvm, self.output_tvm)
-
-        return self.output_tvm.numpy()
-
-
-class BenchmarkConv2dTVMO1(BenchmarkConv2d):
-    """Optimized TVM implementation with adaptive tiling and parallelism"""
-
-    def __init__(self):
-        super().__init__('tvm-o1', True)
-
-    def preprocess(self, x_np, w_np, b_np, stride, padding, dilation, groups):
-        self.input_shape = x_np.shape
-        self.weight_shape = w_np.shape
-        self.dtype = str(x_np.dtype)
-
-        self.input_tvm = tvm.nd.array(x_np, device=tvm.cpu())
-        self.weight_tvm = tvm.nd.array(w_np, device=tvm.cpu())
-        self.bias_tvm = tvm.nd.array(b_np, device=tvm.cpu()) if b_np is not None else None
-
-        self.stride = (stride, stride) if isinstance(stride, int) else stride
-        self.padding = (padding, padding) if isinstance(padding, int) else padding
-        self.dilation = (dilation, dilation) if isinstance(dilation, int) else dilation
-        self.groups = groups
-
-        batch_size, in_channels, in_height, in_width = x_np.shape
-        out_channels, in_channels_per_group, kernel_height, kernel_width = w_np.shape
-
-        A = te.placeholder((batch_size, in_channels, in_height, in_width), name='A', dtype=self.dtype)
-        W = te.placeholder((out_channels, in_channels_per_group, kernel_height, kernel_width), name='W', dtype=self.dtype)
-
-        stride_h, stride_w = self.stride
-        padding_h, padding_w = self.padding
-        dilation_h, dilation_w = self.dilation
-
-        out_height = (in_height + 2 * padding_h - dilation_h * (kernel_height - 1) - 1) // stride_h + 1
-        out_width = (in_width + 2 * padding_w - dilation_w * (kernel_width - 1) - 1) // stride_w + 1
-
-        if groups == 1:
-            # Standard convolution
-            B = topi.nn.conv2d(A, W, strides=self.stride, padding=self.padding, dilation=self.dilation, out_dtype=self.dtype)
-        else:
-            # Split input and weights into `groups` and perform grouped convolution
-            A_splits = te.compute((groups, batch_size, in_channels // groups, in_height, in_width), lambda g, n, c, h, w: A[n, g * (in_channels // groups) + c, h, w], name="A_splits")
-            W_splits = te.compute((groups, out_channels // groups, in_channels // groups, kernel_height, kernel_width), lambda g, oc, ic, kh, kw: W[g * (out_channels // groups) + oc, ic, kh, kw], name="W_splits")
-
-            B_splits = [topi.nn.conv2d(A_splits[g], W_splits[g], strides=self.stride, padding=self.padding, dilation=self.dilation, out_dtype=self.dtype) for g in range(groups)]
-
-            B = topi.concatenate(B_splits, axis=1)  # Concatenate along the channel dimension
-
-        # Add bias if provided
-        if b_np is not None:
-            bias = te.placeholder((out_channels,), name='bias', dtype=self.dtype)
-            B = topi.add(B, topi.reshape(bias, (1, out_channels, 1, 1)))
-            self.has_bias = True
-        else:
-            self.has_bias = False
-
-        s = te.create_schedule(B.op)
-
-        # Apply optimization strategies
-        # Get the output axes
-        n, f, y, x = s[B].op.axis
-
-        # Adapt tile sizes based on input dimensions
-        # For larger inputs, use larger tiles to reduce overhead
-        if out_width >= 56:
-            tile_size_n = min(batch_size, 2)  # Adapt to batch size
-            tile_size_f = min(32, out_channels // 2)  # Adapt to output channels
-            tile_size_y = min(8, out_height // 4)
-            tile_size_x = min(32, out_width // 4)
-        else:
-            tile_size_n = 1
-            tile_size_f = min(16, out_channels // 2)
-            tile_size_y = min(4, out_height // 2)
-            tile_size_x = min(16, out_width // 2)
-
-        # Apply tiling to the axes
-        no, ni = s[B].split(n, factor=tile_size_n)
-        fo, fi = s[B].split(f, factor=tile_size_f)
-        yo, yi = s[B].split(y, factor=tile_size_y)
-        xo, xi = s[B].split(x, factor=tile_size_x)
-
-        # Choose different reordering based on problem size
-        if out_channels >= 64:
-            # For larger problems, parallelize over channels
-            s[B].reorder(fo, no, yo, xo, ni, fi, yi, xi)
-            if self.parallel:
-                s[B].parallel(fo)  # Parallelize over output channels
-        else:
-            # For smaller problems, focus on spatial locality
-            s[B].reorder(no, fo, yo, xo, ni, fi, yi, xi)
-            if self.parallel:
-                # Choose whether to parallelize batch or channels
-                if batch_size > 1:
-                    s[B].parallel(no)
-                else:
-                    s[B].parallel(fo)
-
-        # Apply vectorization to the innermost loop if the width is large enough
-        if out_width >= 16:
-            s[B].vectorize(xi)
-
-        # Build the function
-        if self.has_bias:
-            self.func = tvm.build(s, [A, W, bias, B], target="llvm", name="conv2d_o1")
-            self.output_tvm = tvm.nd.empty((batch_size, out_channels, out_height, out_width), 
-                                        dtype=self.dtype, device=tvm.cpu())
-        else:
-            self.func = tvm.build(s, [A, W, B], target="llvm", name="conv2d_o1")
-            self.output_tvm = tvm.nd.empty((batch_size, out_channels, out_height, out_width), 
-                                        dtype=self.dtype, device=tvm.cpu())
-
-    def process(self):
-        # Execute the function
-        if self.has_bias:
-            self.func(self.input_tvm, self.weight_tvm, self.bias_tvm, self.output_tvm)
-        else:
-            self.func(self.input_tvm, self.weight_tvm, self.output_tvm)
-        
-        return self.output_tvm.numpy()
+            self.func(self.input_tvm, self.weight_tvm, self.out_tvm)
+        return self.out_tvm.numpy()
 
 
 if __name__ == "__main__":
-    # Test the convolution with a simple example
-    batch_size, in_channels, in_height, in_width = 1, 3, 32, 32
-    out_channels, kernel_height, kernel_width = 16, 3, 3
-    
-    x_np = np.random.rand(batch_size, in_channels, in_height, in_width).astype(np.float32)
-    w_np = np.random.rand(out_channels, in_channels, kernel_height, kernel_width).astype(np.float32)
-    b_np = np.random.rand(out_channels).astype(np.float32)
-    
-    # Verify with PyTorch
-    x_torch = torch.tensor(x_np, dtype=torch.float32)
-    w_torch = torch.tensor(w_np, dtype=torch.float32)
-    b_torch = torch.tensor(b_np, dtype=torch.float32)
-    expected = torch.nn.functional.conv2d(x_torch, w_torch, b_torch).numpy()
-
-    # Test with TVM
-    benchmark = BenchmarkConv2dTVMO1()
-    result = benchmark.benchmark(x_np, w_np, expected, b_np, 1, 0, 1, 1, False)
-    result_parallel = benchmark.benchmark(x_np, w_np, expected, b_np, 1, 0, 1, 1, True)
-
-    print(f"{result}")
-    print(f"parallel: {result_parallel}") 
+    benchmark = BenchmarkConv2dTVM()
+    df = run_benchmarks([benchmark])
+    print(f"\nBenchmark Results:\n{df}")
 

--- a/cases/conv2d/conv2d_tvm.py
+++ b/cases/conv2d/conv2d_tvm.py
@@ -1,0 +1,238 @@
+# TVM Benchmark
+# Refer to: https://tvm.apache.org/docs/reference/api/python/topi.html#tvm.topi.nn.conv2d
+
+import numpy as np
+import torch
+import tvm
+from tvm import te, topi
+from BenchmarkConv2d import BenchmarkConv2d
+
+
+class BenchmarkConv2dTVM(BenchmarkConv2d):
+
+    def __init__(self):
+        super().__init__('tvm', True)
+
+    def preprocess(self, x_np, w_np, b_np, stride, padding, dilation, groups):
+        self.input_shape = x_np.shape
+        self.weight_shape = w_np.shape
+        self.dtype = str(x_np.dtype)
+
+        # Convert to TVM tensors
+        self.input_tvm = tvm.nd.array(x_np, device=tvm.cpu())
+        self.weight_tvm = tvm.nd.array(w_np, device=tvm.cpu())
+        self.bias_tvm = tvm.nd.array(b_np, device=tvm.cpu()) if b_np is not None else None
+
+        # Handle parameter formats
+        self.stride = (stride, stride) if isinstance(stride, int) else stride
+        self.padding = (padding, padding) if isinstance(padding, int) else padding
+        self.dilation = (dilation, dilation) if isinstance(dilation, int) else dilation
+        self.groups = groups
+
+        # Create placeholders for the computation
+        batch_size, in_channels, in_height, in_width = x_np.shape
+        out_channels, in_channels_per_group, kernel_height, kernel_width = w_np.shape
+
+        # Create input and weight tensors
+        A = te.placeholder((batch_size, in_channels, in_height, in_width), name='A', dtype=self.dtype)
+        W = te.placeholder((out_channels, in_channels_per_group, kernel_height, kernel_width), name='W', dtype=self.dtype)
+
+        # Define the convolution computation
+        stride_h, stride_w = self.stride
+        padding_h, padding_w = self.padding
+        dilation_h, dilation_w = self.dilation
+
+        # Compute output dimensions
+        out_height = (in_height + 2 * padding_h - dilation_h * (kernel_height - 1) - 1) // stride_h + 1
+        out_width = (in_width + 2 * padding_w - dilation_w * (kernel_width - 1) - 1) // stride_w + 1
+
+        if groups == 1:
+            # Standard convolution
+            B = topi.nn.conv2d(A, W, strides=self.stride, padding=self.padding, dilation=self.dilation, out_dtype=self.dtype)
+        else:
+            # Split input and weights into `groups` and perform grouped convolution
+            A_splits = te.compute((groups, batch_size, in_channels // groups, in_height, in_width), lambda g, n, c, h, w: A[n, g * (in_channels // groups) + c, h, w], name="A_splits")
+            W_splits = te.compute((groups, out_channels // groups, in_channels // groups, kernel_height, kernel_width), lambda g, oc, ic, kh, kw: W[g * (out_channels // groups) + oc, ic, kh, kw], name="W_splits")
+
+            B_splits = [topi.nn.conv2d(A_splits[g], W_splits[g], strides=self.stride, padding=self.padding, dilation=self.dilation, out_dtype=self.dtype) for g in range(groups)]
+
+            B = topi.concatenate(B_splits, axis=1)  # Concatenate along the channel dimension
+
+        # Add bias if provided
+        if b_np is not None:
+            bias = te.placeholder((out_channels,), name='bias', dtype=self.dtype)
+            B = topi.add(B, topi.reshape(bias, (1, out_channels, 1, 1)))
+            self.has_bias = True
+        else:
+            self.has_bias = False
+
+        s = te.create_schedule(B.op)
+
+        # Apply parallelization if needed
+        if self.parallel:
+            output_op = s[B].op
+            if isinstance(output_op, tvm.te.ComputeOp):
+                n, f, y, x = output_op.axis
+                s[B].parallel(n)
+
+        # Build the function
+        if self.has_bias:
+            self.func = tvm.build(s, [A, W, bias, B], target="llvm", name="conv2d")
+            self.output_tvm = tvm.nd.empty((batch_size, out_channels, out_height, out_width), 
+                                        dtype=self.dtype, device=tvm.cpu())
+        else:
+            self.func = tvm.build(s, [A, W, B], target="llvm", name="conv2d")
+            self.output_tvm = tvm.nd.empty((batch_size, out_channels, out_height, out_width), 
+                                        dtype=self.dtype, device=tvm.cpu())
+
+    def process(self):
+        # Execute the function
+        if self.has_bias:
+            self.func(self.input_tvm, self.weight_tvm, self.bias_tvm, self.output_tvm)
+        else:
+            self.func(self.input_tvm, self.weight_tvm, self.output_tvm)
+
+        return self.output_tvm.numpy()
+
+
+class BenchmarkConv2dTVMO1(BenchmarkConv2d):
+    """Optimized TVM implementation with adaptive tiling and parallelism"""
+
+    def __init__(self):
+        super().__init__('tvm-o1', True)
+
+    def preprocess(self, x_np, w_np, b_np, stride, padding, dilation, groups):
+        self.input_shape = x_np.shape
+        self.weight_shape = w_np.shape
+        self.dtype = str(x_np.dtype)
+
+        self.input_tvm = tvm.nd.array(x_np, device=tvm.cpu())
+        self.weight_tvm = tvm.nd.array(w_np, device=tvm.cpu())
+        self.bias_tvm = tvm.nd.array(b_np, device=tvm.cpu()) if b_np is not None else None
+
+        self.stride = (stride, stride) if isinstance(stride, int) else stride
+        self.padding = (padding, padding) if isinstance(padding, int) else padding
+        self.dilation = (dilation, dilation) if isinstance(dilation, int) else dilation
+        self.groups = groups
+
+        batch_size, in_channels, in_height, in_width = x_np.shape
+        out_channels, in_channels_per_group, kernel_height, kernel_width = w_np.shape
+
+        A = te.placeholder((batch_size, in_channels, in_height, in_width), name='A', dtype=self.dtype)
+        W = te.placeholder((out_channels, in_channels_per_group, kernel_height, kernel_width), name='W', dtype=self.dtype)
+
+        stride_h, stride_w = self.stride
+        padding_h, padding_w = self.padding
+        dilation_h, dilation_w = self.dilation
+
+        out_height = (in_height + 2 * padding_h - dilation_h * (kernel_height - 1) - 1) // stride_h + 1
+        out_width = (in_width + 2 * padding_w - dilation_w * (kernel_width - 1) - 1) // stride_w + 1
+
+        if groups == 1:
+            # Standard convolution
+            B = topi.nn.conv2d(A, W, strides=self.stride, padding=self.padding, dilation=self.dilation, out_dtype=self.dtype)
+        else:
+            # Split input and weights into `groups` and perform grouped convolution
+            A_splits = te.compute((groups, batch_size, in_channels // groups, in_height, in_width), lambda g, n, c, h, w: A[n, g * (in_channels // groups) + c, h, w], name="A_splits")
+            W_splits = te.compute((groups, out_channels // groups, in_channels // groups, kernel_height, kernel_width), lambda g, oc, ic, kh, kw: W[g * (out_channels // groups) + oc, ic, kh, kw], name="W_splits")
+
+            B_splits = [topi.nn.conv2d(A_splits[g], W_splits[g], strides=self.stride, padding=self.padding, dilation=self.dilation, out_dtype=self.dtype) for g in range(groups)]
+
+            B = topi.concatenate(B_splits, axis=1)  # Concatenate along the channel dimension
+
+        # Add bias if provided
+        if b_np is not None:
+            bias = te.placeholder((out_channels,), name='bias', dtype=self.dtype)
+            B = topi.add(B, topi.reshape(bias, (1, out_channels, 1, 1)))
+            self.has_bias = True
+        else:
+            self.has_bias = False
+
+        s = te.create_schedule(B.op)
+
+        # Apply optimization strategies
+        # Get the output axes
+        n, f, y, x = s[B].op.axis
+
+        # Adapt tile sizes based on input dimensions
+        # For larger inputs, use larger tiles to reduce overhead
+        if out_width >= 56:
+            tile_size_n = min(batch_size, 2)  # Adapt to batch size
+            tile_size_f = min(32, out_channels // 2)  # Adapt to output channels
+            tile_size_y = min(8, out_height // 4)
+            tile_size_x = min(32, out_width // 4)
+        else:
+            tile_size_n = 1
+            tile_size_f = min(16, out_channels // 2)
+            tile_size_y = min(4, out_height // 2)
+            tile_size_x = min(16, out_width // 2)
+
+        # Apply tiling to the axes
+        no, ni = s[B].split(n, factor=tile_size_n)
+        fo, fi = s[B].split(f, factor=tile_size_f)
+        yo, yi = s[B].split(y, factor=tile_size_y)
+        xo, xi = s[B].split(x, factor=tile_size_x)
+
+        # Choose different reordering based on problem size
+        if out_channels >= 64:
+            # For larger problems, parallelize over channels
+            s[B].reorder(fo, no, yo, xo, ni, fi, yi, xi)
+            if self.parallel:
+                s[B].parallel(fo)  # Parallelize over output channels
+        else:
+            # For smaller problems, focus on spatial locality
+            s[B].reorder(no, fo, yo, xo, ni, fi, yi, xi)
+            if self.parallel:
+                # Choose whether to parallelize batch or channels
+                if batch_size > 1:
+                    s[B].parallel(no)
+                else:
+                    s[B].parallel(fo)
+
+        # Apply vectorization to the innermost loop if the width is large enough
+        if out_width >= 16:
+            s[B].vectorize(xi)
+
+        # Build the function
+        if self.has_bias:
+            self.func = tvm.build(s, [A, W, bias, B], target="llvm", name="conv2d_o1")
+            self.output_tvm = tvm.nd.empty((batch_size, out_channels, out_height, out_width), 
+                                        dtype=self.dtype, device=tvm.cpu())
+        else:
+            self.func = tvm.build(s, [A, W, B], target="llvm", name="conv2d_o1")
+            self.output_tvm = tvm.nd.empty((batch_size, out_channels, out_height, out_width), 
+                                        dtype=self.dtype, device=tvm.cpu())
+
+    def process(self):
+        # Execute the function
+        if self.has_bias:
+            self.func(self.input_tvm, self.weight_tvm, self.bias_tvm, self.output_tvm)
+        else:
+            self.func(self.input_tvm, self.weight_tvm, self.output_tvm)
+        
+        return self.output_tvm.numpy()
+
+
+if __name__ == "__main__":
+    # Test the convolution with a simple example
+    batch_size, in_channels, in_height, in_width = 1, 3, 32, 32
+    out_channels, kernel_height, kernel_width = 16, 3, 3
+    
+    x_np = np.random.rand(batch_size, in_channels, in_height, in_width).astype(np.float32)
+    w_np = np.random.rand(out_channels, in_channels, kernel_height, kernel_width).astype(np.float32)
+    b_np = np.random.rand(out_channels).astype(np.float32)
+    
+    # Verify with PyTorch
+    x_torch = torch.tensor(x_np, dtype=torch.float32)
+    w_torch = torch.tensor(w_np, dtype=torch.float32)
+    b_torch = torch.tensor(b_np, dtype=torch.float32)
+    expected = torch.nn.functional.conv2d(x_torch, w_torch, b_torch).numpy()
+
+    # Test with TVM
+    benchmark = BenchmarkConv2dTVMO1()
+    result = benchmark.benchmark(x_np, w_np, expected, b_np, 1, 0, 1, 1, False)
+    result_parallel = benchmark.benchmark(x_np, w_np, expected, b_np, 1, 0, 1, 1, True)
+
+    print(f"{result}")
+    print(f"parallel: {result_parallel}") 
+

--- a/cases/transpose/BenchmarkTranspose.py
+++ b/cases/transpose/BenchmarkTranspose.py
@@ -1,8 +1,13 @@
 from abc import ABC, abstractmethod
+from typing import Callable, List
 import numpy as np
+import numpy.typing as npt
 import time
+import pandas as pd
 
-from config import measurement_iterations, warmup_iterations
+num_warmup = 200
+num_execution = 400
+benchmark_name = "transpose"
 
 class BenchmarkTranspose(ABC):
 
@@ -12,36 +17,54 @@ class BenchmarkTranspose(ABC):
         self.parallel = False
 
     @abstractmethod
-    def process(self, x):
-        """ Where processing really happens
-
-        Args:
-            x: transformed input data, like torch tensor or tvm NDArray
-
-        Returns:
-            Processed data in the form of ndarray of numpy.
-            (Because some frameworks like hidet and tvm have `lazy execution`,
-            transform the result directly in this function trigger the execution,
-            or there will be some strange bugs)
-
-        """
+    def process(self) -> npt.NDArray:
         pass
 
     @abstractmethod
-    def preprocess(self, x_np):
+    def preprocess(self, x_np) -> float:
         pass
 
-    def benchmark(self, x_np, parallel = False):
-        self.parallel = parallel
-        x = self.preprocess(x_np)
+    @staticmethod
+    def measure(f: Callable, *args) -> float:
+        start = time.perf_counter()
+        f(*args)
+        end = time.perf_counter()
+        return round((end - start) * 1000, 3)
 
-        times = []
-        result = []
-        for _ in range(measurement_iterations):
-            start = time.perf_counter()
-            result = self.process(x)
-            end = time.perf_counter()
-            times.append(round((end - start) * 1000, 3))
-        
-        return np.mean(times[warmup_iterations:]), np.array(result), times[:warmup_iterations]
+    def benchmark(self, x_np, expected, parallel = True):
+        self.parallel = parallel
+        print(f"  Running {self.name}...")
+
+        tuning_time = self.preprocess(x_np)
+        result = self.process()
+        assert np.allclose(result, expected, atol=1e-3, rtol=1e-3), f"{self.name} result mismatch!"
+        times = [self.measure(self.process) for _ in range(num_execution)]
+        exec_time = np.mean(times[num_warmup:])
+
+        return {
+            'Benchmark': benchmark_name,
+            'Shape': f"{x_np.shape}",
+            'Method': self.name,
+            'Time(ms)': exec_time,
+            'TuningTime(ms)': tuning_time
+        }
+
+def run_benchmarks(benchmarks: List[BenchmarkTranspose]):
+    shapes = [(1024, 768), (2048, 1536), (4096, 3072)]
+
+    records = []
+    for shape in shapes:
+        M, N = shape
+        x_np = np.random.rand(M, N).astype(np.float32)
+        expected = x_np.T
+
+        print(f"\nBenchmarking shape {shape}...")
+        for benchmark in benchmarks:
+            records.append(benchmark.benchmark(x_np, expected))
+
+    # Create and save the benchmark results
+    df = pd.DataFrame(records)
+    setattr(df, 'name', benchmark_name)
+
+    return df
 

--- a/cases/transpose/config.py
+++ b/cases/transpose/config.py
@@ -1,6 +1,0 @@
-benchmark = "transpose"
-warmup_iterations = 10  # Warmup iterations before timing
-measurement_iterations = 20  # Number of iterations for measurement
-benchmark_parallel = True
-# repeat_runs = 3  # Number of times to repeat the entire benchmark
-# confidence_interval = 0.95  # For calculating confidence intervals

--- a/cases/transpose/transpose_hidet.py
+++ b/cases/transpose/transpose_hidet.py
@@ -1,29 +1,20 @@
-import numpy as np
 import hidet
-from BenchmarkTranspose import BenchmarkTranspose
+from BenchmarkTranspose import BenchmarkTranspose, run_benchmarks
 
-class BenchmarkHidet(BenchmarkTranspose):
+class BenchmarkTransposeHidet(BenchmarkTranspose):
 
     def __init__(self):
         super().__init__('hidet', False)
 
     def preprocess(self, x_np):
-        return hidet.graph.from_numpy(x_np)
+        self.x = hidet.graph.from_numpy(x_np)
+        return 0.0
 
-    def process(self, x):
-        return hidet.ops.transpose(x).numpy()
+    def process(self):
+        return hidet.ops.transpose(self.x).numpy()
 
 if __name__ == "__main__":
-    M, N = 1024, 768
-    x_np = np.random.rand(M, N).astype(np.float32)
+    benchmark = BenchmarkTransposeHidet()
+    df = run_benchmarks([benchmark])
+    print(f"\nBenchmark Results:\n{df}")
 
-    benchmark = BenchmarkHidet()
-    time_hidet, result_hidet, warmup_times = benchmark.benchmark(x_np)
-
-    # Verify correctness
-    expected = x_np.transpose()
-    assert np.allclose(result_hidet, expected, atol=1e-3, rtol=1e-3), (
-        "Hidet result mismatch!"
-    )
-
-    print(f"hidet: {time_hidet}, warmup times: {warmup_times}")

--- a/cases/transpose/transpose_triton.py
+++ b/cases/transpose/transpose_triton.py
@@ -1,95 +1,46 @@
 import torch
-import numpy as np
 import triton
 import triton.language as tl
 import os
 
-from BenchmarkTranspose import BenchmarkTranspose
+from BenchmarkTranspose import BenchmarkTranspose, run_benchmarks
 
 def get_configs():
     configs = []
-    for BLOCK_SIZE_M in [16, 32, 64]:
-        for BLOCK_SIZE_N in [16, 32, 64]:
+    for BLOCK_SIZE_M in [16, 32, 64, 128]:
+        for BLOCK_SIZE_N in [16, 32, 64, 128]:
             configs.append(triton.Config({'BLOCK_SIZE_M': BLOCK_SIZE_M, 'BLOCK_SIZE_N': BLOCK_SIZE_N}))
     return configs
 
-# Enable full autotuning for benchmarking
 @triton.autotune(get_configs(), key=['M', 'N'])
 @triton.jit
 def transpose_kernel(
-    # Pointers to matrices
     input_ptr, output_ptr,
-    # Matrix dimensions
     M, N,
-    # The stride variables
     input_stride_m, input_stride_n,
     output_stride_m, output_stride_n,
-    # Meta-parameters
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr
 ):
-    """Optimized kernel for computing the transpose of a matrix.
-    Input has shape (M, N), output has shape (N, M)
-    """
-    # Map program ids to the block of the output it should compute
     pid = tl.program_id(axis=0)
     num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
     pid_m = pid // num_pid_n
     pid_n = pid % num_pid_n
 
-    # Create offsets for the blocks
     offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
     offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
-    
-    # Create input and output pointers for the entire block
+
     input_ptrs = input_ptr + offs_m[:, None] * input_stride_m + offs_n[None, :] * input_stride_n
-    
-    # Create masks to handle boundary conditions
     mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
-    
-    # Load the block from input
+
     block = tl.load(input_ptrs, mask=mask)
-    
-    # Transpose the block in SRAM
     block_t = tl.trans(block)
-    
-    # Store the transposed block to output
-    # Note: we need to swap m and n for the output
+
+    # NOTE: we need to swap m and n for the output
     output_ptrs = output_ptr + offs_n[:, None] * output_stride_m + offs_m[None, :] * output_stride_n
-    # We need to transpose the mask as well
     mask_t = tl.trans(mask)
     tl.store(output_ptrs, block_t, mask=mask_t)
 
-def transpose(x, y=None):
-    """Compute the transpose of a matrix using Triton.
-    
-    Args:
-        x: Input matrix(tensor or ndarray or...) of shape (M, N)
-        y: Optional output tensor of shape (N, M)
-        
-    Returns:
-        Transposed tensor of shape (N, M)
-    """
-    M, N = x.shape
-    
-    # Allocate output if not provided
-    if not isinstance(x, torch.Tensor):
-        x = torch.tensor(x, device='cpu', dtype=torch.float32)
-    if y is None:
-        y = torch.empty((N, M), dtype=x.dtype, device=x.device)
-    
-    # Launch the kernel with a 2D grid where each block gets its own program
-    grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), )
-    
-    transpose_kernel[grid](
-        x, y,
-        M, N,
-        x.stride(0), x.stride(1),
-        y.stride(0), y.stride(1),
-        )
-    
-    return y
-
-class BenchmarkTriton(BenchmarkTranspose):
+class BenchmarkTransposeTriton(BenchmarkTranspose):
 
     def __init__(self):
         super().__init__('triton', True)
@@ -97,24 +48,34 @@ class BenchmarkTriton(BenchmarkTranspose):
     def preprocess(self, x_np):
         os.environ["TRITON_CPU_BACKEND"] = "1"
         os.environ["TRITON_CPU_MAX_THREADS"] = "0" if self.parallel else "1"
-        return torch.tensor(x_np, device='cpu', dtype=torch.float32)
+        M, N = x_np.shape
 
-    def process(self, x):
-        return transpose(x)
+        self.x = torch.tensor(x_np, device='cpu', dtype=torch.float32)
+        self.y = torch.empty((N, M), dtype=self.x.dtype, device=self.x.device)
+        self.grid = lambda META: (triton.cdiv(M, META['BLOCK_SIZE_M']) * triton.cdiv(N, META['BLOCK_SIZE_N']), )
+
+        # for debug
+        self.already_print = False
+
+        return self.measure(self.process)
+
+    def process(self):
+        M, N = self.x.shape
+        transpose_kernel[self.grid](
+            self.x, self.y,
+            M, N,
+            self.x.stride(0), self.x.stride(1),
+            self.y.stride(0), self.y.stride(1),
+        )
+
+        if not self.already_print:
+            print(f"    Best config: {transpose_kernel.best_config}")
+            self.already_print = True
+
+        return self.y
 
 if __name__ == "__main__":
-    M, N = 1024, 768
-    x_np = np.random.rand(M, N).astype(np.float32)
-    benchmarkTriton = BenchmarkTriton()
-    expect = x_np.transpose()
-    
-    time_triton, result_triton, warmup_times = benchmarkTriton.benchmark(x_np)
-    time_triton_parallel, result_triton_parallel, warpup_times_parallel = benchmarkTriton.benchmark(x_np, True)
-    
-    # Verify correctness
-    assert np.allclose(result_triton, expect, atol=1e-3, rtol=1e-3), "Triton result mismatch!"
-    assert np.allclose(result_triton_parallel, expect, atol=1e-3, rtol=1e-3), "Triton parallel result mismatch!"
-    
-    print(f"Triton single: {time_triton} ms (tuning: {warmup_times} ms)")
-    print(f"Triton parallel: {time_triton_parallel} ms (tuning: {warmup_times} ms)")
+    benchmark = BenchmarkTransposeTriton()
+    df = run_benchmarks([benchmark])
+    print(f"\nBenchmark Results:\n{df}")
 

--- a/cases/transpose/transpose_tvm.py
+++ b/cases/transpose/transpose_tvm.py
@@ -1,51 +1,43 @@
-import numpy as np
 import tvm
 from tvm import te
 import tvm.topi as topi
-from BenchmarkTranspose import BenchmarkTranspose
+from BenchmarkTranspose import BenchmarkTranspose, run_benchmarks
 
-class BenchmarkTVMNaive(BenchmarkTranspose):
+class BenchmarkTransposeTVMNaive(BenchmarkTranspose):
 
     def __init__(self):
         super().__init__('tvm-naive', False)
-        
+
     def preprocess(self, x_np):
-        # Create TVM context and tensors
-        self.M, self.N = x_np.shape
         self.dtype = str(x_np.dtype)
-        
-        # Define the computation
-        A = te.placeholder((self.M, self.N), name='A', dtype=self.dtype)
+        M, N = x_np.shape
+
+        A = te.placeholder((M, N), name='A', dtype=self.dtype)
         B: tvm.te.Tensor = topi.transpose(A)
-        
-        # Create schedule
         s = te.create_schedule(B.op)
-        
-        # Build the function
         self.func = tvm.build(s, [A, B], target="llvm", name="transpose")
-        
-        # Create TVM arrays
+
         self.a_tvm = tvm.nd.array(x_np, device=tvm.cpu())
-        self.b_tvm = tvm.nd.empty((self.N, self.M), dtype=self.dtype, device=tvm.cpu())
-        
-        return self.a_tvm
-        
-    def process(self, x):
+        self.b_tvm = tvm.nd.empty((N, M), dtype=self.dtype, device=tvm.cpu())
+
+        return 0.0
+
+    def process(self):
         # Execute the function
-        self.func(x, self.b_tvm)
+        self.func(self.a_tvm, self.b_tvm)
         return self.b_tvm.numpy()
 
-class BenchmarkTVMO1(BenchmarkTranspose):
+class BenchmarkTransposeTVMO1(BenchmarkTranspose):
     """Optimized with parallelism, vectorize and loop tiling"""
 
     def __init__(self):
         super().__init__('tvm-o1', False)
 
     def preprocess(self, x_np):
-        self.M, self.N = x_np.shape
         self.dtype = str(x_np.dtype)
+        M, N = x_np.shape
 
-        A = te.placeholder((self.M, self.N), name='A', dtype=self.dtype)
+        A = te.placeholder((M, N), name='A', dtype=self.dtype)
         B: tvm.te.Tensor = topi.transpose(A)
 
         s: tvm.te.schedule.Schedule = te.create_schedule(B.op)
@@ -53,38 +45,24 @@ class BenchmarkTVMO1(BenchmarkTranspose):
         block_size = 32  # TODO: Tune this based on CPU cache line size
         x, y = s[B].op.axis
 
-        # **Loop Tiling (Cache Optimization)**
         xo, _ = s[B].split(x, factor=block_size)
         _, yi = s[B].split(y, factor=block_size)
 
         s[B].parallel(xo)  # Parallelize the outer loop
         s[B].vectorize(yi)  # Apply vectorization to the inner loop
 
-        # Build the optimized function
         self.func = tvm.build(s, [A, B], target="llvm", name="transpose")
-
-        # Allocate TVM arrays
         self.a_tvm = tvm.nd.array(x_np, device=tvm.cpu())
-        self.b_tvm = tvm.nd.empty((self.N, self.M), dtype=self.dtype, device=tvm.cpu())
+        self.b_tvm = tvm.nd.empty((N, M), dtype=self.dtype, device=tvm.cpu())
 
-        return self.a_tvm
+        return 0.0
 
-    def process(self, x):
-        # Execute the compiled function
-        self.func(x, self.b_tvm)
+    def process(self):
+        self.func(self.a_tvm, self.b_tvm)
         return self.b_tvm.numpy()
 
 if __name__ == "__main__":
-    M, N = 1024, 768
-    x_np = np.random.rand(M, N).astype(np.float32)
+    benchmark = BenchmarkTransposeTVMO1()
+    df = run_benchmarks([benchmark])
+    print(f"\nBenchmark Results:\n{df}")
 
-    benchmark = BenchmarkTVMO1()
-    time_tvm, result_tvm, warmup_times = benchmark.benchmark(x_np)
-
-    # Verify correctness
-    expected = x_np.transpose()
-    assert np.allclose(result_tvm, expected, atol=1e-3, rtol=1e-3), (
-        "TVM result mismatch!"
-    )
-
-    print(f"tvm: {time_tvm}, warmup times: {warmup_times}") 


### PR DESCRIPTION
I accidently discard the commit I committed several days ago, so now I start a new PR with it and a new one together.

Now apart from transpose_autotvm(which I've written long ago, it's almost done) and transpose_ansor, all other methods for conv2d and transpose have already be implemented and waited to be optimized.

I've tried many configs for triton to autotuning, it seems to improving well in transpose, though remaining hard to beat torch.
In benchmark, every method will run 400 times, I take the mean of the later 200 times as result.
Benchmark result of transpose:
![Screenshot_20250408_231937](https://github.com/user-attachments/assets/9b0b309f-3039-41e4-9558-caac5c6691b5)
Benchmark result of conv2d:
![Screenshot_20250408_232221-1](https://github.com/user-attachments/assets/be289595-967a-439f-a57a-58ef21241007)

Even though I run 400 times, the result of torch is still varied a lot sometimes for conv2d. I run execution 200 times before, but the result for torch is unstable, which is why I switch to 400. 