### PR TITLE
Modify print settings and optimize code

### DIFF
--- a/benchmarks/patch/triton-cpu-0002-autotuning.patch
+++ b/benchmarks/patch/triton-cpu-0002-autotuning.patch
@@ -51,10 +51,10 @@ index c9833c94..cb4e4a99 100644
 -        if config.pre_hook is not None:
 -            full_nargs = {**self.nargs, **kwargs, **config.all_kwargs()}
 -            config.pre_hook(full_nargs)
-+        # self.best_config = config
-+        # if os.getenv("TRITON_PRINT_AUTOTUNING", None) == "1" and not used_cached_result:
-+        #     print(f"Triton autotuning for function {self.base_fn.__name__} finished after "
-+        #           f"{self.bench_time:.2f}s; best config selected: {self.best_config};")
++        self.best_config = config
++        if os.getenv("TRITON_PRINT_AUTOTUNING", None) == "1" and not used_cached_result:
++            print(f"Triton autotuning for function {self.base_fn.__name__} finished after "
++                  f"{self.bench_time:.2f}s; best config selected: {self.best_config};")
 +        # if config.pre_hook is not None:
 +        #     full_nargs = {**self.nargs, **kwargs, **config.all_kwargs()}
 +        #     config.pre_hook(full_nargs)

--- a/cases/vecadd/benchmark.py
+++ b/cases/vecadd/benchmark.py
@@ -77,8 +77,8 @@ def main():
 
         for method, method_func in methods:
             print(f"Running {method} benchmark for shape {shape}...")
-            run_benchmark(method, method_func, shape, a_np, b_np, torch_result)
-            records.append(run_benchmark(method, method_func, shape, a_np, b_np, torch_result))
+            benchmark_result = run_benchmark(method, method_func, shape, a_np, b_np, torch_result)
+            records.append(benchmark_result)
 
     df = pd.DataFrame(records)
     df.sort_values(by=['Benchmark', 'Shape'], inplace=True)

--- a/cases/vecadd/vecadd_triton.py
+++ b/cases/vecadd/vecadd_triton.py
@@ -12,7 +12,7 @@ triton.runtime.driver.set_active_to_cpu()
 # Triton Benchmark
 def get_vector_add_kernel_autotune_config(num_threads=0):
     configs = []
-    for BLOCK_SIZE in [1024,2048,4096, 8192, 16384]:
+    for BLOCK_SIZE in [1024, 2048, 4096, 8192, 16384]:
         for TILE_SIZE in [16, 32, 64, 128]:
             configs.append(triton.Config({'BLOCK_SIZE': BLOCK_SIZE, 'TILE_SIZE': TILE_SIZE}, num_threads=num_threads))
     return configs


### PR DESCRIPTION
Main modification:
in triton-benchmark/benchmarks/patch/triton-cpu-0002-autotuning.patch
Uncomment the print statements related to TRITON_PRINT_AUTOTUNING so that it can print the optimal parameters as expected.

in triton-benchmark/cases/vecadd/benchmark.py
Reduced an additional function call, improving the efficiency of the code.

in triton-benchmark/cases/vecadd/vecadd_triton.py
Formatted the code and added spaces